### PR TITLE
🐛 [Bug fix]: geometryフィールドの型定義を修正

### DIFF
--- a/src/tools/file/get-file-nodes-args.ts
+++ b/src/tools/file/get-file-nodes-args.ts
@@ -5,7 +5,7 @@ export const GetFileNodesArgsSchema = z.object({
   file_key: z.string().describe('The Figma file key'),
   ids: z.array(z.string()).min(1).describe('Array of node IDs to fetch'),
   depth: z.number().optional().describe('Depth of nodes to fetch'),
-  geometry: z.string().optional().describe('Geometry type to include'),
+  geometry: z.enum(['paths', 'points']).optional().describe('Geometry type to include'),
   branch_data: z.boolean().optional().describe('Include branch data'),
   version: z.string().optional().describe('Version ID to fetch'),
   plugin_data: z.string().optional().describe('Plugin data to include'),


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- `GetFileNodesArgsSchema`の`geometry`フィールドの型定義を修正
- `z.string()`から`z.enum(['paths', 'points'])`に変更し、`GetFileOptions`型と一致するように修正

## Test plan
- [ ] TypeScriptの型エラーが解消されることを確認
- [ ] VSCodeでエラー表示が消えることを確認
- [ ] ビルドが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)