### PR TITLE
♻️ APIレスポンス型定義のプロパティ名をキャメルケースに統一

### DIFF
--- a/src/tools/image/export.test.ts
+++ b/src/tools/image/export.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import type { FigmaApiClient } from '../../api/figma-api-client.js';
-import type { ExportImagesResponse } from '../../types/api/responses/image-responses.js';
+import type { ExportImageResponse } from '../../types/api/responses/image-responses.js';
 
 describe('export-images', () => {
   let mockApiClient: FigmaApiClient;
@@ -19,7 +19,7 @@ describe('export-images', () => {
     const format = 'png';
     const scale = 2;
 
-    const mockResponse: ExportImagesResponse = {
+    const mockResponse: ExportImageResponse = {
       err: undefined,
       images: {
         '1:2': 'https://figma-export.com/image1.png',
@@ -45,7 +45,7 @@ describe('export-images', () => {
     const fileKey = 'test-file-key';
     const ids = ['1:2'];
 
-    const mockResponse: ExportImagesResponse = {
+    const mockResponse: ExportImageResponse = {
       err: undefined,
       images: {
         '1:2': 'https://figma-export.com/image1.png',
@@ -70,7 +70,7 @@ describe('export-images', () => {
     const ids = ['1:2'];
     const format = 'svg';
 
-    const mockResponse: ExportImagesResponse = {
+    const mockResponse: ExportImageResponse = {
       err: undefined,
       images: {
         '1:2': 'https://figma-export.com/image1.svg',
@@ -111,7 +111,7 @@ describe('export-images', () => {
     const fileKey = 'test-file-key';
     const ids = ['1:2'];
 
-    const mockResponse: ExportImagesResponse = {
+    const mockResponse: ExportImageResponse = {
       err: 'Invalid node ID',
       images: {},
     };

--- a/src/tools/image/export.ts
+++ b/src/tools/image/export.ts
@@ -1,6 +1,6 @@
 import type { FigmaApiClient } from '../../api/figma-api-client.js';
 import type { ImageTool } from './types.js';
-import type { ExportImagesResponse } from '../../types/api/responses/image-responses.js';
+import type { ExportImageResponse } from '../../types/api/responses/image-responses.js';
 import { ExportImagesArgsSchema, type ExportImagesArgs } from './export-images-args.js';
 import { JsonSchema } from '../types.js';
 
@@ -9,7 +9,7 @@ export const createExportImagesTool = (apiClient: FigmaApiClient): ImageTool => 
     name: 'export_images',
     description: 'Export images from a Figma file',
     inputSchema: JsonSchema.from(ExportImagesArgsSchema),
-    execute: async (args: ExportImagesArgs): Promise<ExportImagesResponse> => {
+    execute: async (args: ExportImagesArgs): Promise<ExportImageResponse> => {
       const { fileKey, ...options } = args;
       return apiClient.exportImages(fileKey, options);
     },

--- a/src/tools/image/types.ts
+++ b/src/tools/image/types.ts
@@ -1,9 +1,9 @@
 import type { ToolDefinition } from '../types.js';
-import type { ExportImagesResponse } from '../../types/api/responses/image-responses.js';
+import type { ExportImageResponse } from '../../types/api/responses/image-responses.js';
 import type { ExportImagesArgs } from './export-images-args.js';
 
-export interface ImageTool extends ToolDefinition<ExportImagesArgs, ExportImagesResponse> {
+export interface ImageTool extends ToolDefinition<ExportImagesArgs, ExportImageResponse> {
   name: string;
   description: string;
-  execute: (args: ExportImagesArgs) => Promise<ExportImagesResponse>;
+  execute: (args: ExportImagesArgs) => Promise<ExportImageResponse>;
 }

--- a/src/types/api/responses/image-responses.ts
+++ b/src/types/api/responses/image-responses.ts
@@ -5,6 +5,3 @@ export interface ExportImageResponse {
   images: Record<string, string>;
   status?: number;
 }
-
-// エイリアス（互換性のため）
-export type ExportImagesResponse = ExportImageResponse;

--- a/src/types/api/responses/team-responses.ts
+++ b/src/types/api/responses/team-responses.ts
@@ -11,7 +11,7 @@ export interface GetProjectFilesResponse {
   files: Array<{
     key: string;
     name: string;
-    thumbnail_url: string;
-    last_modified: string;
+    thumbnailUrl: string;
+    lastModified: string;
   }>;
 }


### PR DESCRIPTION
## 概要
APIレスポンスの型定義でスネークケースになっていたプロパティ名をキャメルケースに統一しました。
また、不要な互換性エイリアスを削除しました。

## 変更内容
### 1. プロパティ名のキャメルケース変換
- `GetProjectFilesResponse` の型定義を修正
  - `thumbnail_url` → `thumbnailUrl`
  - `last_modified` → `lastModified`

### 2. 不要なエイリアスの削除
- `ExportImagesResponse` エイリアスを削除
- 関連するすべての使用箇所を `ExportImageResponse` に変更
  - `src/tools/image/types.ts`
  - `src/tools/image/export.ts`
  - `src/tools/image/export.test.ts`

## テスト
- ✅ すべてのテスト（215個）が成功
- ✅ lint チェック: エラーなし
- ✅ TypeScript コンパイル: 成功

## レビューポイント
- 型定義の命名規則の統一性
- エイリアス削除による影響範囲の確認

🤖 Generated with [Claude Code](https://claude.ai/code)