### PR TITLE
🐛 [Fix]: Dockerビルド時の権限エラーを修正

### DIFF
--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -38,6 +38,12 @@ WORKDIR /app
 # Copy package files (optimized for production)
 COPY --chown=nodejs:nodejs package*.json ./
 
+# Create node_modules directory with proper ownership
+RUN mkdir -p node_modules && chown -R nodejs:nodejs /app
+
+# Create necessary directories (before switching to non-root user)
+RUN mkdir -p /app/logs && chown -R nodejs:nodejs /app/logs
+
 # Switch to non-root user before installing dependencies
 USER nodejs
 
@@ -49,9 +55,6 @@ RUN npm ci --omit=dev && \
 
 # Copy only the built application from builder stage
 COPY --from=builder --chown=nodejs:nodejs /app/dist ./dist
-
-# Create necessary directories
-RUN mkdir -p /app/logs && chown -R nodejs:nodejs /app/logs
 
 # Expose MCP server port
 EXPOSE 8765


### PR DESCRIPTION
## 概要
Dockerビルド時に発生していた権限エラーを修正しました。

## 修正内容
### 1. npm ciの実行時の権限エラー
- **問題**: `/app/node_modules`への書き込み権限がない
- **原因**: `nodejs`ユーザーで`npm ci`を実行するが、ディレクトリの所有者が`root`
- **修正**: `node_modules`ディレクトリを事前に作成し、適切な所有権を設定

### 2. logsディレクトリ作成時の権限エラー
- **問題**: `/app/logs`の所有権変更ができない
- **原因**: `USER nodejs`の後で`chown`コマンドを実行していた
- **修正**: ディレクトリ作成と所有権設定を`USER nodejs`の前に移動

## 変更ファイル
- `mcp-server/Dockerfile`

## テスト結果
- ✅ Dockerビルドが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)