### PR TITLE
♻️ [Refactoring]: snake_case型定義を削除してDeepSnakeCaseユーティリティを使用

### DIFF
--- a/src/api/endpoints/files.test.ts
+++ b/src/api/endpoints/files.test.ts
@@ -78,11 +78,11 @@ describe('createFilesApi', () => {
         expectedParams: 'geometry=paths',
       },
       {
-        options: { plugin_data: 'test-plugin' },
+        options: { pluginData: 'test-plugin' },
         expectedParams: 'plugin_data=test-plugin',
       },
       {
-        options: { branch_data: true },
+        options: { branchData: true },
         expectedParams: 'branch_data=true',
       },
     ])('オプション$optionsを正しくパラメータ化する', async ({ options, expectedParams }) => {
@@ -101,8 +101,8 @@ describe('createFilesApi', () => {
         ids: ['1:1', '2:2'],
         depth: 2,
         geometry: 'points',
-        plugin_data: 'my-plugin',
-        branch_data: false,
+        pluginData: 'my-plugin',
+        branchData: false,
       };
 
       vi.mocked(mockHttpClient.get).mockResolvedValueOnce({} as FigmaFile);
@@ -131,11 +131,11 @@ describe('createFilesApi', () => {
       expect(calledParams?.toString()).toBe('depth=0');
     });
 
-    test('branch_dataがfalseの場合も正しくパラメータ化される', async () => {
+    test('branchDataがfalseの場合も正しくパラメータ化される', async () => {
       vi.mocked(mockHttpClient.get).mockResolvedValueOnce({} as FigmaFile);
 
       const filesApi = createFilesApi(mockHttpClient);
-      await filesApi.getFile(TestData.FILE_KEY, { branch_data: false });
+      await filesApi.getFile(TestData.FILE_KEY, { branchData: false });
 
       const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
       expect(calledParams?.toString()).toBe('branch_data=false');

--- a/src/api/endpoints/files.ts
+++ b/src/api/endpoints/files.ts
@@ -22,9 +22,9 @@ export function createFilesApi(client: HttpClient): FilesApi {
         if (options.ids) params.append('ids', options.ids.join(','));
         if (options.depth !== undefined) params.append('depth', options.depth.toString());
         if (options.geometry) params.append('geometry', options.geometry);
-        if (options.plugin_data) params.append('plugin_data', options.plugin_data);
-        if (options.branch_data !== undefined)
-          params.append('branch_data', options.branch_data.toString());
+        if (options.pluginData) params.append('plugin_data', options.pluginData);
+        if (options.branchData !== undefined)
+          params.append('branch_data', options.branchData.toString());
       }
 
       return client.get<FigmaFile>(`/v1/files/${fileKey}`, params);
@@ -42,9 +42,9 @@ export function createFilesApi(client: HttpClient): FilesApi {
         if (options.version) params.append('version', options.version);
         if (options.depth !== undefined) params.append('depth', options.depth.toString());
         if (options.geometry) params.append('geometry', options.geometry);
-        if (options.plugin_data) params.append('plugin_data', options.plugin_data);
-        if (options.branch_data !== undefined)
-          params.append('branch_data', options.branch_data.toString());
+        if (options.pluginData) params.append('plugin_data', options.pluginData);
+        if (options.branchData !== undefined)
+          params.append('branch_data', options.branchData.toString());
       }
 
       return client.get<GetFileNodesResponse>(`/v1/files/${fileKey}/nodes`, params);

--- a/src/api/endpoints/images.ts
+++ b/src/api/endpoints/images.ts
@@ -2,17 +2,18 @@
 
 import type { HttpClient } from '../client.js';
 import type { ExportImageResponse } from '../../types/index.js';
-import type { ExportImageOptionsSnake } from '../../types/api/options/image-options.js';
+import type { ExportImageOptions } from '../../types/api/options/image-options.js';
+import type { DeepSnakeCase } from '../../utils/type-transformers.js';
 
 export interface ImagesApi {
-  exportImages: (fileKey: string, options: ExportImageOptionsSnake) => Promise<ExportImageResponse>;
+  exportImages: (fileKey: string, options: DeepSnakeCase<ExportImageOptions>) => Promise<ExportImageResponse>;
 }
 
 export function createImagesApi(client: HttpClient): ImagesApi {
   return {
     exportImages: async (
       fileKey: string,
-      options: ExportImageOptionsSnake
+      options: DeepSnakeCase<ExportImageOptions>
     ): Promise<ExportImageResponse> => {
       const params = new URLSearchParams();
 

--- a/src/api/endpoints/nodes.ts
+++ b/src/api/endpoints/nodes.ts
@@ -2,15 +2,16 @@
 
 import type { HttpClient } from '../client.js';
 import type { GetNodesResponse } from '../../types/index.js';
-import type { GetNodesOptionsSnake } from '../../types/api/options/node-options.js';
+import type { GetNodesOptions } from '../../types/api/options/node-options.js';
+import type { DeepSnakeCase } from '../../utils/type-transformers.js';
 
 export interface NodesApi {
-  getNodes: (fileKey: string, options: GetNodesOptionsSnake) => Promise<GetNodesResponse>;
+  getNodes: (fileKey: string, options: DeepSnakeCase<GetNodesOptions>) => Promise<GetNodesResponse>;
 }
 
 export function createNodesApi(client: HttpClient): NodesApi {
   return {
-    getNodes: async (fileKey: string, options: GetNodesOptionsSnake): Promise<GetNodesResponse> => {
+    getNodes: async (fileKey: string, options: DeepSnakeCase<GetNodesOptions>): Promise<GetNodesResponse> => {
       const params = new URLSearchParams();
 
       params.append('ids', options.ids.join(','));

--- a/src/api/figma-api-client.ts
+++ b/src/api/figma-api-client.ts
@@ -67,8 +67,6 @@ export class FigmaApiClient {
   }
 
   async exportImages(fileKey: string, options: ExportImageOptions): Promise<ExportImageResponse> {
-    // optionsは既にExportImageOptions (DeepCamelCase<ExportImageOptionsSnake>)型
-    // convertKeysToSnakeCaseでスネークケースに戻す
     const snakeOptions = convertKeysToSnakeCase(options);
     const response = await this.images.exportImages(fileKey, snakeOptions);
     return convertKeysToCamelCase(response);

--- a/src/tools/file/info.test.ts
+++ b/src/tools/file/info.test.ts
@@ -86,7 +86,7 @@ describe('info tool', () => {
     });
 
     expect(filesApi.getFile).toHaveBeenCalledWith('test-file-key', {
-      branch_data: true,
+      branchData: true,
     });
   });
 

--- a/src/tools/file/info.ts
+++ b/src/tools/file/info.ts
@@ -14,9 +14,9 @@ export function createGetFileTool(
     inputSchema: JsonSchema.from(GetFileArgsSchema),
     execute: async (args: GetFileArgs): Promise<FileResponse> => {
       const options: GetFileOptions = {
-        branch_data: args.branch_data,
+        branchData: args.branch_data,
         version: args.version,
-        plugin_data: args.plugin_data,
+        pluginData: args.plugin_data,
       };
 
       // Remove undefined values

--- a/src/tools/file/nodes.ts
+++ b/src/tools/file/nodes.ts
@@ -16,9 +16,9 @@ export function createGetFileNodesTool(
       const options: GetFileOptions = {
         depth: args.depth,
         geometry: args.geometry,
-        branch_data: args.branch_data,
+        branchData: args.branch_data,
         version: args.version,
-        plugin_data: args.plugin_data,
+        pluginData: args.plugin_data,
       };
 
       // Remove undefined values

--- a/src/types/api/options/file-options.ts
+++ b/src/types/api/options/file-options.ts
@@ -5,6 +5,6 @@ export interface GetFileOptions {
   ids?: string[];
   depth?: number;
   geometry?: 'paths' | 'points';
-  plugin_data?: string;
-  branch_data?: boolean;
+  pluginData?: string;
+  branchData?: boolean;
 }

--- a/src/types/api/options/image-options.ts
+++ b/src/types/api/options/image-options.ts
@@ -1,17 +1,11 @@
 // 画像エクスポート関連のAPIオプション型定義
 
-import type { DeepCamelCase } from '../../../utils/type-transformers.js';
-
-// APIリクエスト用のスネークケース型（内部使用）
-export interface ExportImageOptionsSnake {
+export interface ExportImageOptions {
   ids: string[];
   scale?: number;
   format?: 'jpg' | 'png' | 'svg' | 'pdf';
-  svg_include_id?: boolean;
-  svg_simplify_stroke?: boolean;
-  use_absolute_bounds?: boolean;
+  svgIncludeId?: boolean;
+  svgSimplifyStroke?: boolean;
+  useAbsoluteBounds?: boolean;
   version?: string;
 }
-
-// アプリケーション用のキャメルケース型
-export type ExportImageOptions = DeepCamelCase<ExportImageOptionsSnake>;

--- a/src/types/api/options/node-options.ts
+++ b/src/types/api/options/node-options.ts
@@ -1,15 +1,9 @@
 // ノード関連のAPIオプション型定義
 
-import type { DeepCamelCase } from '../../../utils/type-transformers.js';
-
-// APIリクエスト用のスネークケース型（内部使用）
-export interface GetNodesOptionsSnake {
+export interface GetNodesOptions {
   ids: string[];
   version?: string;
   depth?: number;
   geometry?: 'paths' | 'points';
-  plugin_data?: string;
+  pluginData?: string;
 }
-
-// アプリケーション用のキャメルケース型
-export type GetNodesOptions = DeepCamelCase<GetNodesOptionsSnake>;

--- a/src/types/figma-types.ts
+++ b/src/types/figma-types.ts
@@ -1,7 +1,5 @@
 // Figmaの基本型定義
 
-import type { DeepCamelCase } from '../utils/type-transformers.js';
-
 export interface Color {
   r: number;
   g: number;
@@ -119,25 +117,19 @@ export interface Document {
   children: Node[];
 }
 
-// APIレスポンス用のスネークケース型（内部使用）
-export interface ComponentSnake {
+export interface Component {
   key: string;
   name: string;
   description: string;
   componentSetId?: string;
   documentationLinks: DocumentationLink[];
-  // 追加フィールド
-  file_key?: string;
-  node_id?: string;
-  containing_frame?: {
-    page_id: string;
-    page_name: string;
+  fileKey?: string;
+  nodeId?: string;
+  containingFrame?: {
+    pageId: string;
+    pageName: string;
   };
-  component_set_id?: string;
 }
-
-// アプリケーション用のキャメルケース型
-export type Component = DeepCamelCase<ComponentSnake>;
 
 export interface ComponentSet {
   key: string;
@@ -146,80 +138,59 @@ export interface ComponentSet {
   documentationLinks: DocumentationLink[];
 }
 
-// APIレスポンス用のスネークケース型（内部使用）
-export interface StyleSnake {
+export interface Style {
   key: string;
-  file_key: string;
-  node_id: string;
-  style_type: 'FILL' | 'TEXT' | 'EFFECT' | 'GRID';
+  fileKey: string;
+  nodeId: string;
+  styleType: 'FILL' | 'TEXT' | 'EFFECT' | 'GRID';
   name: string;
   description: string;
   remote?: boolean;
-  sort_position?: string;
+  sortPosition?: string;
 }
-
-// アプリケーション用のキャメルケース型
-export type Style = DeepCamelCase<StyleSnake>;
 
 export interface DocumentationLink {
   uri: string;
 }
 
-// APIレスポンス用のスネークケース型（内部使用）
-export interface FigmaUserSnake {
+export interface FigmaUser {
   id: string;
   handle: string;
-  img_url: string;
+  imgUrl: string;
   email: string;
 }
 
-// アプリケーション用のキャメルケース型
-export type FigmaUser = DeepCamelCase<FigmaUserSnake>;
-
-// APIレスポンス用のスネークケース型（内部使用）
-export interface CommentSnake {
+export interface Comment {
   id: string;
-  file_key: string;
-  parent_id?: string;
-  user: FigmaUserSnake;
-  created_at: string;
-  resolved_at?: string;
+  fileKey: string;
+  parentId?: string;
+  user: FigmaUser;
+  createdAt: string;
+  resolvedAt?: string;
   message: string;
-  client_meta: {
-    node_id?: string[];
-    node_offset?: Vector;
+  clientMeta: {
+    nodeId?: string[];
+    nodeOffset?: Vector;
     [key: string]: unknown;
   };
-  order_id: string;
-  reactions?: ReactionSnake[];
+  orderId: string;
+  reactions?: Reaction[];
 }
 
-// アプリケーション用のキャメルケース型
-export type Comment = DeepCamelCase<CommentSnake>;
-
-// APIレスポンス用のスネークケース型（内部使用）
-export interface ReactionSnake {
-  user: FigmaUserSnake;
-  created_at: string;
+export interface Reaction {
+  user: FigmaUser;
+  createdAt: string;
   emoji: string;
 }
 
-// アプリケーション用のキャメルケース型
-export type Reaction = DeepCamelCase<ReactionSnake>;
-
-// APIレスポンス用のスネークケース型（内部使用）
-export interface VersionSnake {
+export interface Version {
   id: string;
-  created_at: string;
+  createdAt: string;
   label: string;
   description: string;
-  user: FigmaUserSnake;
-  // 詳細情報（オプション）
-  thumbnail_url?: string;
-  pages_changed?: string[];
-  components_changed?: number;
-  styles_changed?: number;
+  user: FigmaUser;
+  thumbnailUrl?: string;
+  pagesChanged?: string[];
+  componentsChanged?: number;
+  stylesChanged?: number;
 }
-
-// アプリケーション用のキャメルケース型
-export type Version = DeepCamelCase<VersionSnake>;


### PR DESCRIPTION
## 概要

snake_caseで定義されていた型を削除し、`DeepSnakeCase`型変換ユーティリティを使用するようにリファクタリングしました。これにより、型定義の重複が解消され、保守性が向上しました。

## 変更内容

### 型定義の統一
以下の型をsnake_caseからcamelCaseに変更：
- `ComponentSnake` → `Component`
- `StyleSnake` → `Style`
- `FigmaUserSnake` → `FigmaUser`
- `CommentSnake` → `Comment`
- `ReactionSnake` → `Reaction`
- `VersionSnake` → `Version`
- `ExportImageOptionsSnake` → `ExportImageOptions`
- `GetNodesOptionsSnake` → `GetNodesOptions`

### プロパティ名の変更
- `plugin_data` → `pluginData`
- `branch_data` → `branchData`

### 実装の修正
- APIエンドポイントで`DeepSnakeCase<T>`を使用してsnake_case変換を実現
- 依存箇所（テストファイル、ツール実装）を新しい型定義に対応
- 実装の意図以外の不要なコメントを削除

## テスト結果

- ✅ TypeScript型チェック: すべて通過
- ✅ 単体テスト: 231/231 成功
- ✅ ESLint: エラーなし

## メリット

1. **型定義の重複解消**: snake_caseとcamelCaseの二重定義が不要に
2. **保守性向上**: 型定義の変更が一箇所で管理可能
3. **一貫性**: アプリケーション全体でcamelCaseに統一

🤖 Generated with [Claude Code](https://claude.ai/code)