### PR TITLE
♻️ [Refactoring]: Phase 2.2 - データ型のコンパニオンオブジェクトパターン実装

### DIFF
--- a/src/api/data/component.test.ts
+++ b/src/api/data/component.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { ComponentData } from './component.js';
+import type { FigmaContext } from '../context.js';
+import type { GetComponentsResponse } from '../../types/api/responses/component-responses.js';
+
+describe('ComponentData', () => {
+  const mockContext: FigmaContext = {
+    accessToken: 'test-token',
+    baseUrl: 'https://api.figma.com',
+    headers: {
+      'X-Figma-Token': 'test-token',
+    },
+  };
+
+  describe('インターフェース', () => {
+    it('必要なプロパティを持つ', () => {
+      const componentData: ComponentData = {
+        key: 'component-key',
+        fileKey: 'file-key',
+        nodeId: '1:1',
+        name: 'Button Component',
+        description: 'Primary button component',
+        containingFrame: {
+          nodeId: '2:2',
+          name: 'Button Frame',
+          backgroundColor: '#FFFFFF',
+          pageName: 'Components',
+        },
+      };
+
+      expect(componentData.key).toBe('component-key');
+      expect(componentData.name).toBe('Button Component');
+      expect(componentData.containingFrame.pageName).toBe('Components');
+    });
+  });
+
+  describe('ComponentData.fromResponse', () => {
+    it('Figma APIレスポンスからComponentDataを作成できる', () => {
+      const response: GetComponentsResponse = {
+        meta: {
+          components: [
+            {
+              key: 'comp-123',
+              file_key: 'file-abc',
+              node_id: '3:3',
+              name: 'Card Component',
+              description: 'Card layout component',
+              containing_frame: {
+                nodeId: '4:4',
+                name: 'Card Frame',
+                backgroundColor: '#F0F0F0',
+                pageName: 'Design System',
+              },
+            } as any,
+          ],
+        },
+      };
+
+      const components = ComponentData.fromResponse(response);
+
+      expect(components).toHaveLength(1);
+      expect(components[0].key).toBe('comp-123');
+      expect(components[0].fileKey).toBe('file-abc');
+      expect(components[0].nodeId).toBe('3:3');
+      expect(components[0].name).toBe('Card Component');
+    });
+
+    it('複数のコンポーネントを処理できる', () => {
+      const response: GetComponentsResponse = {
+        meta: {
+          components: [
+            {
+              key: 'comp-1',
+              file_key: 'file-1',
+              node_id: '1:1',
+              name: 'Component 1',
+              description: '',
+              containing_frame: {
+                nodeId: '0:0',
+                name: 'Frame 1',
+                backgroundColor: '',
+                pageName: 'Page 1',
+              },
+            } as any,
+            {
+              key: 'comp-2',
+              file_key: 'file-1',
+              node_id: '2:2',
+              name: 'Component 2',
+              description: '',
+              containing_frame: {
+                nodeId: '0:1',
+                name: 'Frame 2',
+                backgroundColor: '',
+                pageName: 'Page 2',
+              },
+            } as any,
+          ],
+        },
+      };
+
+      const components = ComponentData.fromResponse(response);
+
+      expect(components).toHaveLength(2);
+      expect(components[0].name).toBe('Component 1');
+      expect(components[1].name).toBe('Component 2');
+    });
+
+    it('空のレスポンスを処理できる', () => {
+      const response: GetComponentsResponse = {
+        meta: {
+          components: [],
+        },
+      };
+
+      const components = ComponentData.fromResponse(response);
+
+      expect(components).toEqual([]);
+    });
+  });
+
+  describe('ComponentData.fetchAll', () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it('指定されたファイルのコンポーネント一覧を取得できる', async () => {
+      const mockResponse: GetComponentsResponse = {
+        meta: {
+          components: [
+            {
+              key: 'fetch-comp-1',
+              file_key: 'test-file',
+              node_id: '5:5',
+              name: 'Fetched Component',
+              description: 'Test component',
+              containing_frame: {
+                nodeId: '6:6',
+                name: 'Container',
+                backgroundColor: '#000000',
+                pageName: 'Test Page',
+              },
+            } as any,
+          ],
+        },
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      const components = await ComponentData.fetchAll(mockContext, 'test-file');
+
+      expect(components).toHaveLength(1);
+      expect(components[0].key).toBe('fetch-comp-1');
+      expect(components[0].name).toBe('Fetched Component');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.figma.com/v1/files/test-file/components',
+        expect.objectContaining({
+          method: 'GET',
+          headers: mockContext.headers,
+        })
+      );
+    });
+
+    it('APIエラーの場合は例外を投げる', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+      } as Response);
+
+      await expect(
+        ComponentData.fetchAll(mockContext, 'forbidden-file')
+      ).rejects.toThrow('Failed to fetch components: 403 Forbidden');
+    });
+  });
+
+  describe('ComponentData.groupByPage', () => {
+    it('コンポーネントをページごとにグループ化できる', () => {
+      const components: ComponentData[] = [
+        {
+          key: 'comp-1',
+          fileKey: 'file-1',
+          nodeId: '1:1',
+          name: 'Button',
+          description: '',
+          containingFrame: {
+            nodeId: '0:0',
+            name: 'Buttons',
+            backgroundColor: '',
+            pageName: 'Components',
+          },
+        },
+        {
+          key: 'comp-2',
+          fileKey: 'file-1',
+          nodeId: '2:2',
+          name: 'Card',
+          description: '',
+          containingFrame: {
+            nodeId: '0:1',
+            name: 'Cards',
+            backgroundColor: '',
+            pageName: 'Components',
+          },
+        },
+        {
+          key: 'comp-3',
+          fileKey: 'file-1',
+          nodeId: '3:3',
+          name: 'Icon',
+          description: '',
+          containingFrame: {
+            nodeId: '0:2',
+            name: 'Icons',
+            backgroundColor: '',
+            pageName: 'Icons',
+          },
+        },
+      ];
+
+      const grouped = ComponentData.groupByPage(components);
+
+      expect(Object.keys(grouped)).toEqual(['Components', 'Icons']);
+      expect(grouped['Components']).toHaveLength(2);
+      expect(grouped['Icons']).toHaveLength(1);
+      expect(grouped['Components'][0].name).toBe('Button');
+      expect(grouped['Components'][1].name).toBe('Card');
+      expect(grouped['Icons'][0].name).toBe('Icon');
+    });
+
+    it('空の配列を処理できる', () => {
+      const grouped = ComponentData.groupByPage([]);
+
+      expect(grouped).toEqual({});
+    });
+  });
+
+  describe('ComponentData.filterByName', () => {
+    const components: ComponentData[] = [
+      {
+        key: 'comp-1',
+        fileKey: 'file-1',
+        nodeId: '1:1',
+        name: 'Primary Button',
+        description: '',
+        containingFrame: {
+          nodeId: '0:0',
+          name: 'Buttons',
+          backgroundColor: '',
+          pageName: 'Components',
+        },
+      },
+      {
+        key: 'comp-2',
+        fileKey: 'file-1',
+        nodeId: '2:2',
+        name: 'Secondary Button',
+        description: '',
+        containingFrame: {
+          nodeId: '0:1',
+          name: 'Buttons',
+          backgroundColor: '',
+          pageName: 'Components',
+        },
+      },
+      {
+        key: 'comp-3',
+        fileKey: 'file-1',
+        nodeId: '3:3',
+        name: 'Card',
+        description: '',
+        containingFrame: {
+          nodeId: '0:2',
+          name: 'Cards',
+          backgroundColor: '',
+          pageName: 'Components',
+        },
+      },
+    ];
+
+    it('名前でコンポーネントをフィルタリングできる', () => {
+      const filtered = ComponentData.filterByName(components, 'Button');
+
+      expect(filtered).toHaveLength(2);
+      expect(filtered[0].name).toBe('Primary Button');
+      expect(filtered[1].name).toBe('Secondary Button');
+    });
+
+    it('大文字小文字を区別しない', () => {
+      const filtered = ComponentData.filterByName(components, 'button');
+
+      expect(filtered).toHaveLength(2);
+    });
+
+    it('部分一致で検索できる', () => {
+      const filtered = ComponentData.filterByName(components, 'Pri');
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].name).toBe('Primary Button');
+    });
+
+    it('一致しない場合は空配列を返す', () => {
+      const filtered = ComponentData.filterByName(components, 'NonExistent');
+
+      expect(filtered).toEqual([]);
+    });
+  });
+});

--- a/src/api/data/component.ts
+++ b/src/api/data/component.ts
@@ -1,0 +1,137 @@
+import type { FigmaContext } from '../context.js';
+import type { GetComponentsResponse } from '../../types/api/responses/component-responses.js';
+
+/**
+ * APIレスポンスのコンポーネント型
+ */
+interface ApiComponent {
+  key: string;
+  file_key: string;
+  node_id: string;
+  name: string;
+  description?: string;
+  containing_frame: {
+    nodeId: string;
+    name: string;
+    backgroundColor?: string;
+    pageName: string;
+  };
+}
+
+/**
+ * コンポーネントのコンテナフレーム情報
+ */
+export interface ContainingFrame {
+  /** ノードID */
+  readonly nodeId: string;
+  /** フレーム名 */
+  readonly name: string;
+  /** 背景色 */
+  readonly backgroundColor: string;
+  /** ページ名 */
+  readonly pageName: string;
+}
+
+/**
+ * Figmaコンポーネントのデータ構造
+ */
+export interface ComponentData {
+  /** コンポーネントのキー */
+  readonly key: string;
+  /** ファイルキー */
+  readonly fileKey: string;
+  /** ノードID */
+  readonly nodeId: string;
+  /** コンポーネント名 */
+  readonly name: string;
+  /** 説明 */
+  readonly description: string;
+  /** コンテナフレーム情報 */
+  readonly containingFrame: ContainingFrame;
+}
+
+/**
+ * ComponentDataのコンパニオンオブジェクト
+ * コンポーネントデータの取得と操作のための純粋関数を提供
+ */
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace ComponentData {
+  /**
+   * Figma APIレスポンスからComponentDataの配列を作成
+   */
+  export function fromResponse(response: GetComponentsResponse): ComponentData[] {
+    if (!response.meta?.components) {
+      return [];
+    }
+
+    // componentsはComponent[]型として定義されているが、実際はApiComponent[]
+    const apiComponents = response.meta.components as unknown as ApiComponent[];
+    return apiComponents.map((comp) => ({
+      key: comp.key,
+      fileKey: comp.file_key,
+      nodeId: comp.node_id,
+      name: comp.name,
+      description: comp.description || '',
+      containingFrame: {
+        nodeId: comp.containing_frame.nodeId,
+        name: comp.containing_frame.name,
+        backgroundColor: comp.containing_frame.backgroundColor || '',
+        pageName: comp.containing_frame.pageName,
+      },
+    }));
+  }
+
+  /**
+   * ファイルのコンポーネント一覧を取得
+   */
+  export async function fetchAll(
+    context: FigmaContext,
+    fileKey: string
+  ): Promise<ComponentData[]> {
+    const url = `${context.baseUrl}/v1/files/${fileKey}/components`;
+    
+    const response = await globalThis.fetch(url, {
+      method: 'GET',
+      headers: context.headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch components: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json() as GetComponentsResponse;
+    return fromResponse(data);
+  }
+
+  /**
+   * コンポーネントをページごとにグループ化
+   */
+  export function groupByPage(
+    components: ComponentData[]
+  ): Record<string, ComponentData[]> {
+    const grouped: Record<string, ComponentData[]> = {};
+
+    for (const component of components) {
+      const pageName = component.containingFrame.pageName;
+      if (!grouped[pageName]) {
+        grouped[pageName] = [];
+      }
+      grouped[pageName].push(component);
+    }
+
+    return grouped;
+  }
+
+  /**
+   * 名前でコンポーネントをフィルタリング
+   */
+  export function filterByName(
+    components: ComponentData[],
+    searchTerm: string
+  ): ComponentData[] {
+    const lowerSearchTerm = searchTerm.toLowerCase();
+    return components.filter(comp => 
+      comp.name.toLowerCase().includes(lowerSearchTerm)
+    );
+  }
+}

--- a/src/api/data/file.test.ts
+++ b/src/api/data/file.test.ts
@@ -1,0 +1,441 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { FileData } from './file.js';
+import type { FigmaContext } from '../context.js';
+import type { FigmaFile } from '../../types/api/responses/file-responses.js';
+
+describe('FileData', () => {
+  const mockContext: FigmaContext = {
+    accessToken: 'test-token',
+    baseUrl: 'https://api.figma.com',
+    headers: {
+      'X-Figma-Token': 'test-token',
+    },
+  };
+
+  describe('インターフェース', () => {
+    it('必要なプロパティを持つ', () => {
+      const fileData: FileData = {
+        key: 'test-file-key',
+        name: 'Test File',
+        lastModified: '2024-01-01T00:00:00Z',
+        thumbnailUrl: 'https://example.com/thumbnail.png',
+        version: '123456789',
+        document: { id: '0:0', name: 'Document', type: 'DOCUMENT', children: [] },
+        components: {},
+        schemaVersion: 0,
+        styles: {},
+        role: 'owner',
+        editorType: 'figma',
+        linkAccess: 'view',
+      };
+
+      expect(fileData.key).toBe('test-file-key');
+      expect(fileData.name).toBe('Test File');
+      expect(fileData.lastModified).toBe('2024-01-01T00:00:00Z');
+    });
+  });
+
+  describe('FileData.fromResponse', () => {
+    it('Figma APIレスポンスからFileDataを作成できる', () => {
+      const response: FigmaFile = {
+        name: 'Design System',
+        lastModified: '2024-01-01T00:00:00Z',
+        thumbnailUrl: 'https://figma.com/thumb.png',
+        version: '987654321',
+        document: { id: '0:0', name: 'Document', type: 'DOCUMENT', children: [] },
+        components: {},
+        componentSets: {},
+        schemaVersion: 0,
+        styles: {},
+        role: 'owner',
+        editorType: 'figma',
+        linkAccess: 'view',
+      };
+
+      const fileData = FileData.fromResponse('file-key-123', response);
+
+      expect(fileData.key).toBe('file-key-123');
+      expect(fileData.name).toBe('Design System');
+      expect(fileData.lastModified).toBe('2024-01-01T00:00:00Z');
+      expect(fileData.version).toBe('987654321');
+      expect(fileData.document).toEqual(response.document);
+    });
+
+    it('オプショナルなフィールドがない場合でも処理できる', () => {
+      const minimalResponse: FigmaFile = {
+        name: 'Minimal File',
+        lastModified: '2024-01-01T00:00:00Z',
+        thumbnailUrl: '',
+        version: '123',
+        document: { id: '0:0', name: 'Document', type: 'DOCUMENT', children: [] },
+        components: {},
+        componentSets: {},
+        schemaVersion: 0,
+        styles: {},
+        role: 'owner',
+        editorType: 'figma',
+        linkAccess: 'view',
+      };
+
+      const fileData = FileData.fromResponse('minimal-key', minimalResponse);
+
+      expect(fileData.key).toBe('minimal-key');
+      expect(fileData.name).toBe('Minimal File');
+      expect(fileData.thumbnailUrl).toBe('');
+    });
+  });
+
+  describe('FileData.fetch', () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it('指定されたファイルキーでファイル情報を取得できる', async () => {
+      const mockResponse: FigmaFile = {
+        name: 'Fetched File',
+        lastModified: '2024-01-01T00:00:00Z',
+        thumbnailUrl: 'https://figma.com/fetched.png',
+        version: '111111',
+        document: { id: '0:0', name: 'Document', type: 'DOCUMENT', children: [] },
+        components: {},
+        componentSets: {},
+        schemaVersion: 0,
+        styles: {},
+        role: 'owner',
+        editorType: 'figma',
+        linkAccess: 'view',
+      };
+
+      // fetchをモック
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      const fileData = await FileData.fetch(mockContext, 'test-file-key');
+
+      expect(fileData.key).toBe('test-file-key');
+      expect(fileData.name).toBe('Fetched File');
+      expect(fileData.version).toBe('111111');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.figma.com/v1/files/test-file-key',
+        expect.objectContaining({
+          method: 'GET',
+          headers: mockContext.headers,
+        })
+      );
+    });
+
+    it('versionパラメータを指定できる', async () => {
+      const mockResponse: FigmaFile = {
+        name: 'Versioned File',
+        lastModified: '2024-01-01T00:00:00Z',
+        thumbnailUrl: '',
+        version: '222222',
+        document: { id: '0:0', name: 'Document', type: 'DOCUMENT', children: [] },
+        components: {},
+        componentSets: {},
+        schemaVersion: 0,
+        styles: {},
+        role: 'owner',
+        editorType: 'figma',
+        linkAccess: 'view',
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      await FileData.fetch(mockContext, 'test-file-key', { version: '222222' });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.figma.com/v1/files/test-file-key?version=222222',
+        expect.any(Object)
+      );
+    });
+
+    it('geometryパラメータを指定できる', async () => {
+      const mockResponse: FigmaFile = {
+        name: 'File with Geometry',
+        lastModified: '2024-01-01T00:00:00Z',
+        thumbnailUrl: '',
+        version: '333333',
+        document: { id: '0:0', name: 'Document', type: 'DOCUMENT', children: [] },
+        components: {},
+        componentSets: {},
+        schemaVersion: 0,
+        styles: {},
+        role: 'owner',
+        editorType: 'figma',
+        linkAccess: 'view',
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      await FileData.fetch(mockContext, 'test-file-key', { geometry: 'paths' });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.figma.com/v1/files/test-file-key?geometry=paths',
+        expect.any(Object)
+      );
+    });
+
+    it('APIエラーの場合は例外を投げる', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      } as Response);
+
+      await expect(
+        FileData.fetch(mockContext, 'non-existent-file')
+      ).rejects.toThrow('Failed to fetch file: 404 Not Found');
+    });
+  });
+
+  describe('FileData.fetchNodes', () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it('指定されたノードIDの詳細情報を取得できる', async () => {
+      const mockResponse = {
+        name: 'File',
+        nodes: {
+          '1:1': {
+            document: {
+              id: '1:1',
+              name: 'Component Node',
+              type: 'COMPONENT',
+              children: [],
+            },
+            components: {},
+            schemaVersion: 0,
+            styles: {},
+          },
+        },
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      const result = await FileData.fetchNodes(mockContext, 'test-file-key', ['1:1']);
+
+      expect(result.nodes['1:1']).toBeDefined();
+      expect(result.nodes['1:1'].document.name).toBe('Component Node');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.figma.com/v1/files/test-file-key/nodes?ids=1%3A1',
+        expect.objectContaining({
+          method: 'GET',
+          headers: mockContext.headers,
+        })
+      );
+    });
+
+    it('複数のノードIDを指定できる', async () => {
+      const mockResponse = {
+        name: 'File',
+        nodes: {
+          '1:1': {
+            document: { id: '1:1', name: 'Node 1', type: 'FRAME', children: [] },
+            components: {},
+            schemaVersion: 0,
+            styles: {},
+          },
+          '2:2': {
+            document: { id: '2:2', name: 'Node 2', type: 'FRAME', children: [] },
+            components: {},
+            schemaVersion: 0,
+            styles: {},
+          },
+        },
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      const result = await FileData.fetchNodes(mockContext, 'test-file-key', ['1:1', '2:2']);
+
+      expect(Object.keys(result.nodes)).toHaveLength(2);
+      expect(result.nodes['1:1'].document.name).toBe('Node 1');
+      expect(result.nodes['2:2'].document.name).toBe('Node 2');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.figma.com/v1/files/test-file-key/nodes?ids=1%3A1%2C2%3A2',
+        expect.any(Object)
+      );
+    });
+
+    it('depthオプションを指定できる', async () => {
+      const mockResponse = {
+        name: 'File',
+        nodes: {},
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      await FileData.fetchNodes(mockContext, 'test-file-key', ['1:1'], { depth: 2 });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.figma.com/v1/files/test-file-key/nodes?ids=1%3A1&depth=2',
+        expect.any(Object)
+      );
+    });
+
+    it('geometryオプションを指定できる', async () => {
+      const mockResponse = {
+        name: 'File',
+        nodes: {},
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      await FileData.fetchNodes(mockContext, 'test-file-key', ['1:1'], { geometry: 'paths' });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.figma.com/v1/files/test-file-key/nodes?ids=1%3A1&geometry=paths',
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('FileData.getPageNames', () => {
+    it('ファイルからページ名のリストを取得できる', () => {
+      const fileData: FileData = {
+        key: 'test-key',
+        name: 'Test File',
+        lastModified: '2024-01-01T00:00:00Z',
+        version: '123',
+        document: {
+          id: '0:0',
+          name: 'Document',
+          type: 'DOCUMENT',
+          children: [
+            { id: '1:1', name: 'Page 1', type: 'CANVAS', children: [] },
+            { id: '2:2', name: 'Page 2', type: 'CANVAS', children: [] },
+            { id: '3:3', name: 'Frame', type: 'FRAME', children: [] }, // Not a page
+          ],
+        },
+        components: {},
+        schemaVersion: 0,
+        styles: {},
+        role: 'owner',
+        editorType: 'figma',
+        linkAccess: 'view',
+      };
+
+      const pageNames = FileData.getPageNames(fileData);
+
+      expect(pageNames).toEqual(['Page 1', 'Page 2']);
+    });
+
+    it('ページがない場合は空配列を返す', () => {
+      const fileData: FileData = {
+        key: 'test-key',
+        name: 'Test File',
+        lastModified: '2024-01-01T00:00:00Z',
+        version: '123',
+        document: {
+          id: '0:0',
+          name: 'Document',
+          type: 'DOCUMENT',
+          children: [],
+        },
+        components: {},
+        schemaVersion: 0,
+        styles: {},
+        role: 'owner',
+        editorType: 'figma',
+        linkAccess: 'view',
+      };
+
+      const pageNames = FileData.getPageNames(fileData);
+
+      expect(pageNames).toEqual([]);
+    });
+  });
+
+  describe('FileData.findNodeById', () => {
+    it('指定されたIDのノードを見つけることができる', () => {
+      const fileData: FileData = {
+        key: 'test-key',
+        name: 'Test File',
+        lastModified: '2024-01-01T00:00:00Z',
+        version: '123',
+        document: {
+          id: '0:0',
+          name: 'Document',
+          type: 'DOCUMENT',
+          children: [
+            {
+              id: '1:1',
+              name: 'Page 1',
+              type: 'CANVAS',
+              children: [
+                {
+                  id: '2:2',
+                  name: 'Target Frame',
+                  type: 'FRAME',
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+        components: {},
+        schemaVersion: 0,
+        styles: {},
+        role: 'owner',
+        editorType: 'figma',
+        linkAccess: 'view',
+      };
+
+      const node = FileData.findNodeById(fileData, '2:2');
+
+      expect(node).toBeDefined();
+      expect(node?.name).toBe('Target Frame');
+      expect(node?.type).toBe('FRAME');
+    });
+
+    it('存在しないIDの場合はundefinedを返す', () => {
+      const fileData: FileData = {
+        key: 'test-key',
+        name: 'Test File',
+        lastModified: '2024-01-01T00:00:00Z',
+        version: '123',
+        document: {
+          id: '0:0',
+          name: 'Document',
+          type: 'DOCUMENT',
+          children: [],
+        },
+        components: {},
+        schemaVersion: 0,
+        styles: {},
+        role: 'owner',
+        editorType: 'figma',
+        linkAccess: 'view',
+      };
+
+      const node = FileData.findNodeById(fileData, 'non-existent');
+
+      expect(node).toBeUndefined();
+    });
+  });
+});

--- a/src/api/data/file.ts
+++ b/src/api/data/file.ts
@@ -1,0 +1,183 @@
+import type { FigmaContext } from '../context.js';
+import type { FigmaFile } from '../../types/api/responses/file-responses.js';
+import type { Document, Node, Component, Style } from '../../types/figma-types.js';
+
+/**
+ * Figmaファイルのデータ構造
+ * ファイル情報、ドキュメント構造、コンポーネント、スタイルを含む
+ */
+export interface FileData {
+  /** ファイルの一意識別子 */
+  readonly key: string;
+  /** ファイル名 */
+  readonly name: string;
+  /** 最終更新日時 */
+  readonly lastModified: string;
+  /** サムネイルURL（オプション） */
+  readonly thumbnailUrl?: string;
+  /** ファイルバージョン */
+  readonly version: string;
+  /** ドキュメント構造 */
+  readonly document: Document;
+  /** コンポーネント定義 */
+  readonly components: Record<string, Component>;
+  /** スキーマバージョン */
+  readonly schemaVersion: number;
+  /** スタイル定義 */
+  readonly styles: Record<string, Style>;
+  /** ユーザーの権限 */
+  readonly role: string;
+  /** エディタータイプ */
+  readonly editorType: string;
+  /** リンクアクセス権限 */
+  readonly linkAccess: string;
+}
+
+/**
+ * FileDataのコンパニオンオブジェクト
+ * ファイルデータの取得と操作のための純粋関数を提供
+ */
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace FileData {
+  /**
+   * Figma APIレスポンスからFileDataを作成
+   */
+  export function fromResponse(key: string, response: FigmaFile): FileData {
+    return {
+      key,
+      name: response.name,
+      lastModified: response.lastModified,
+      thumbnailUrl: response.thumbnailUrl,
+      version: response.version,
+      document: response.document,
+      components: response.components,
+      schemaVersion: response.schemaVersion,
+      styles: response.styles,
+      role: response.role,
+      editorType: response.editorType,
+      linkAccess: response.linkAccess,
+    };
+  }
+
+  /**
+   * ファイル情報を取得
+   */
+  export async function fetch(
+    context: FigmaContext,
+    fileKey: string,
+    options?: {
+      version?: string;
+      geometry?: 'paths';
+    }
+  ): Promise<FileData> {
+    const params = new URLSearchParams();
+    if (options?.version) {
+      params.append('version', options.version);
+    }
+    if (options?.geometry) {
+      params.append('geometry', options.geometry);
+    }
+
+    const url = `${context.baseUrl}/v1/files/${fileKey}${params.toString() ? '?' + params.toString() : ''}`;
+    
+    const response = await globalThis.fetch(url, {
+      method: 'GET',
+      headers: context.headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch file: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json() as FigmaFile;
+    return fromResponse(fileKey, data);
+  }
+
+  /**
+   * 特定ノードの詳細情報を取得
+   */
+  export async function fetchNodes(
+    context: FigmaContext,
+    fileKey: string,
+    nodeIds: string[],
+    options?: {
+      depth?: number;
+      geometry?: 'paths';
+    }
+  ): Promise<{
+    name: string;
+    nodes: Record<string, {
+      document: Node;
+      components: Record<string, Component>;
+      schemaVersion: number;
+      styles: Record<string, Style>;
+    }>;
+  }> {
+    const params = new URLSearchParams();
+    params.append('ids', nodeIds.join(','));
+    if (options?.depth) {
+      params.append('depth', options.depth.toString());
+    }
+    if (options?.geometry) {
+      params.append('geometry', options.geometry);
+    }
+
+    const url = `${context.baseUrl}/v1/files/${fileKey}/nodes?${params.toString()}`;
+    
+    const response = await globalThis.fetch(url, {
+      method: 'GET',
+      headers: context.headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch nodes: ${response.status} ${response.statusText}`);
+    }
+
+    return await response.json() as {
+      name: string;
+      nodes: Record<string, {
+        document: Node;
+        components: Record<string, Component>;
+        schemaVersion: number;
+        styles: Record<string, Style>;
+      }>;
+    };
+  }
+
+  /**
+   * ファイル内のページ名を取得
+   */
+  export function getPageNames(fileData: FileData): string[] {
+    if (!fileData.document || !fileData.document.children) {
+      return [];
+    }
+
+    return fileData.document.children
+      .filter((node) => node.type === 'CANVAS')
+      .map((node) => node.name);
+  }
+
+  /**
+   * 指定されたIDのノードを検索
+   */
+  export function findNodeById(fileData: FileData, nodeId: string): Node | undefined {
+    function searchNode(node: Node): Node | undefined {
+      if (node.id === nodeId) {
+        return node;
+      }
+
+      if (node.children) {
+        for (const child of node.children) {
+          const found = searchNode(child);
+          if (found) {
+            return found;
+          }
+        }
+      }
+
+      return undefined;
+    }
+
+    return searchNode(fileData.document);
+  }
+}

--- a/src/api/data/image.test.ts
+++ b/src/api/data/image.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { ImageExport } from './image.js';
+import type { FigmaContext } from '../context.js';
+import type { ExportImageResponse } from '../../types/api/responses/image-responses.js';
+
+describe('ImageExport', () => {
+  const mockContext: FigmaContext = {
+    accessToken: 'test-token',
+    baseUrl: 'https://api.figma.com',
+    headers: {
+      'X-Figma-Token': 'test-token',
+    },
+  };
+
+  describe('インターフェース', () => {
+    it('必要なプロパティを持つ', () => {
+      const imageExport: ImageExport = {
+        nodeIds: ['1:1', '2:2'],
+        format: 'PNG',
+        scale: 2,
+        urls: {
+          '1:1': 'https://example.com/image1.png',
+          '2:2': 'https://example.com/image2.png',
+        },
+      };
+
+      expect(imageExport.nodeIds).toEqual(['1:1', '2:2']);
+      expect(imageExport.format).toBe('PNG');
+      expect(imageExport.scale).toBe(2);
+      expect(imageExport.urls['1:1']).toBe('https://example.com/image1.png');
+    });
+  });
+
+  describe('ImageExport.fromOptions', () => {
+    it('オプションからImageExportを作成できる', () => {
+      const imageExport = ImageExport.fromOptions({
+        nodeIds: ['3:3'],
+        format: 'SVG',
+        scale: 1,
+      });
+
+      expect(imageExport.nodeIds).toEqual(['3:3']);
+      expect(imageExport.format).toBe('SVG');
+      expect(imageExport.scale).toBe(1);
+      expect(imageExport.urls).toEqual({});
+    });
+
+    it('デフォルト値を使用できる', () => {
+      const imageExport = ImageExport.fromOptions({
+        nodeIds: ['4:4'],
+      });
+
+      expect(imageExport.nodeIds).toEqual(['4:4']);
+      expect(imageExport.format).toBe('PNG');
+      expect(imageExport.scale).toBe(1);
+    });
+
+    it('複数のノードIDを指定できる', () => {
+      const imageExport = ImageExport.fromOptions({
+        nodeIds: ['5:5', '6:6', '7:7'],
+        format: 'JPG',
+      });
+
+      expect(imageExport.nodeIds).toHaveLength(3);
+      expect(imageExport.format).toBe('JPG');
+    });
+  });
+
+  describe('ImageExport.fetch', () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it('画像エクスポートURLを取得できる', async () => {
+      const mockResponse: ExportImageResponse = {
+        images: {
+          '1:1': 'https://s3.amazonaws.com/figma/image1.png',
+          '2:2': 'https://s3.amazonaws.com/figma/image2.png',
+        },
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      const imageExport = await ImageExport.fetch(
+        mockContext,
+        'test-file-key',
+        { nodeIds: ['1:1', '2:2'], format: 'PNG', scale: 2 }
+      );
+
+      expect(imageExport.urls['1:1']).toBe('https://s3.amazonaws.com/figma/image1.png');
+      expect(imageExport.urls['2:2']).toBe('https://s3.amazonaws.com/figma/image2.png');
+      expect(imageExport.format).toBe('PNG');
+      expect(imageExport.scale).toBe(2);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.figma.com/v1/images/test-file-key?ids=1%3A1%2C2%3A2&format=PNG&scale=2',
+        expect.objectContaining({
+          method: 'GET',
+          headers: mockContext.headers,
+        })
+      );
+    });
+
+    it('SVGフォーマットを指定できる', async () => {
+      const mockResponse: ExportImageResponse = {
+        images: {
+          '3:3': 'https://s3.amazonaws.com/figma/image.svg',
+        },
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      await ImageExport.fetch(
+        mockContext,
+        'test-file-key',
+        { nodeIds: ['3:3'], format: 'SVG' }
+      );
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('format=SVG'),
+        expect.any(Object)
+      );
+    });
+
+    it('PDFフォーマットを指定できる', async () => {
+      const mockResponse: ExportImageResponse = {
+        images: {
+          '4:4': 'https://s3.amazonaws.com/figma/document.pdf',
+        },
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      await ImageExport.fetch(
+        mockContext,
+        'test-file-key',
+        { nodeIds: ['4:4'], format: 'PDF' }
+      );
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('format=PDF'),
+        expect.any(Object)
+      );
+    });
+
+    it('スケールを指定できる', async () => {
+      const mockResponse: ExportImageResponse = {
+        images: {
+          '5:5': 'https://s3.amazonaws.com/figma/image@3x.png',
+        },
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      await ImageExport.fetch(
+        mockContext,
+        'test-file-key',
+        { nodeIds: ['5:5'], scale: 3 }
+      );
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('scale=3'),
+        expect.any(Object)
+      );
+    });
+
+    it('APIエラーの場合は例外を投げる', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+      } as Response);
+
+      await expect(
+        ImageExport.fetch(mockContext, 'test-file-key', { nodeIds: ['invalid'] })
+      ).rejects.toThrow('Failed to fetch images: 400 Bad Request');
+    });
+
+    it('空のレスポンスでも正常に処理できる', async () => {
+      const mockResponse: ExportImageResponse = {
+        images: {},
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      const result = await ImageExport.fetch(mockContext, 'test-file-key', { nodeIds: ['invalid'] });
+      
+      expect(result.urls).toEqual({});
+      expect(result.nodeIds).toEqual(['invalid']);
+    });
+  });
+
+  describe('ImageExport.fetchBatch', () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it('複数のバッチを並列で取得できる', async () => {
+      const mockResponse1: ExportImageResponse = {
+        images: {
+          '1:1': 'https://s3.amazonaws.com/figma/batch1.png',
+        },
+      };
+
+      const mockResponse2: ExportImageResponse = {
+        images: {
+          '2:2': 'https://s3.amazonaws.com/figma/batch2.png',
+        },
+      };
+
+      global.fetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockResponse1),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockResponse2),
+        } as Response);
+
+      const results = await ImageExport.fetchBatch(
+        mockContext,
+        'test-file-key',
+        [
+          { nodeIds: ['1:1'], format: 'PNG' },
+          { nodeIds: ['2:2'], format: 'JPG' },
+        ]
+      );
+
+      expect(results).toHaveLength(2);
+      expect(results[0].urls['1:1']).toBe('https://s3.amazonaws.com/figma/batch1.png');
+      expect(results[0].format).toBe('PNG');
+      expect(results[1].urls['2:2']).toBe('https://s3.amazonaws.com/figma/batch2.png');
+      expect(results[1].format).toBe('JPG');
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('空の配列を処理できる', async () => {
+      const results = await ImageExport.fetchBatch(mockContext, 'test-file-key', []);
+
+      expect(results).toEqual([]);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('単一のオプションも処理できる', async () => {
+      const mockResponse: ExportImageResponse = {
+        images: {
+          '3:3': 'https://s3.amazonaws.com/figma/single.png',
+        },
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      const results = await ImageExport.fetchBatch(
+        mockContext,
+        'test-file-key',
+        [{ nodeIds: ['3:3'], format: 'PNG' }]
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0].urls['3:3']).toBe('https://s3.amazonaws.com/figma/single.png');
+    });
+  });
+});

--- a/src/api/data/image.ts
+++ b/src/api/data/image.ts
@@ -1,0 +1,107 @@
+import type { FigmaContext } from '../context.js';
+import type { ExportImageResponse } from '../../types/api/responses/image-responses.js';
+
+/**
+ * 画像エクスポートのフォーマット
+ */
+export type ImageFormat = 'PNG' | 'JPG' | 'SVG' | 'PDF';
+
+/**
+ * 画像エクスポートのオプション
+ */
+export interface ImageExportOptions {
+  /** エクスポートするノードID */
+  readonly nodeIds: string[];
+  /** 画像フォーマット */
+  readonly format?: ImageFormat;
+  /** スケール（0.01〜4） */
+  readonly scale?: number;
+}
+
+/**
+ * 画像エクスポートのデータ構造
+ */
+export interface ImageExport {
+  /** エクスポートしたノードID */
+  readonly nodeIds: string[];
+  /** 画像フォーマット */
+  readonly format: ImageFormat;
+  /** スケール */
+  readonly scale: number;
+  /** ノードIDと画像URLのマップ */
+  readonly urls: Record<string, string>;
+}
+
+/**
+ * ImageExportのコンパニオンオブジェクト
+ * 画像エクスポートの取得と操作のための純粋関数を提供
+ */
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace ImageExport {
+  /**
+   * オプションからImageExportを作成
+   */
+  export function fromOptions(options: ImageExportOptions): ImageExport {
+    return {
+      nodeIds: options.nodeIds,
+      format: options.format || 'PNG',
+      scale: options.scale || 1,
+      urls: {},
+    };
+  }
+
+  /**
+   * 画像をエクスポート
+   */
+  export async function fetch(
+    context: FigmaContext,
+    fileKey: string,
+    options: ImageExportOptions
+  ): Promise<ImageExport> {
+    const params = new URLSearchParams();
+    params.append('ids', options.nodeIds.join(','));
+    params.append('format', options.format || 'PNG');
+    if (options.scale) {
+      params.append('scale', options.scale.toString());
+    }
+
+    const url = `${context.baseUrl}/v1/images/${fileKey}?${params.toString()}`;
+    
+    const response = await globalThis.fetch(url, {
+      method: 'GET',
+      headers: context.headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch images: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json() as ExportImageResponse;
+
+    return {
+      nodeIds: options.nodeIds,
+      format: options.format || 'PNG',
+      scale: options.scale || 1,
+      urls: data.images || {},
+    };
+  }
+
+  /**
+   * 複数の画像エクスポートを並列で実行
+   */
+  export async function fetchBatch(
+    context: FigmaContext,
+    fileKey: string,
+    optionsList: ImageExportOptions[]
+  ): Promise<ImageExport[]> {
+    if (optionsList.length === 0) {
+      return [];
+    }
+
+    const promises = optionsList.map(options =>
+      fetch(context, fileKey, options)
+    );
+
+    return await Promise.all(promises);
+  }
+}


### PR DESCRIPTION
## 概要
Phase 2.2として、FileData, ComponentData, ImageExportの3つのデータ型にコンパニオンオブジェクトパターンを実装しました。

## 変更内容
### FileData (`src/api/data/file.ts`)
- ✅ Figmaファイルデータの型定義
- ✅ `fromResponse()`: APIレスポンスからの変換
- ✅ `fetch()`: ファイル情報の取得
- ✅ `fetchNodes()`: 特定ノードの詳細取得
- ✅ `getPageNames()`: ページ名リストの取得
- ✅ `findNodeById()`: ID指定でのノード検索

### ComponentData (`src/api/data/component.ts`)
- ✅ コンポーネントデータの型定義
- ✅ `fromResponse()`: APIレスポンスからの変換
- ✅ `fetchAll()`: 全コンポーネントの取得
- ✅ `groupByPage()`: ページ別グループ化
- ✅ `filterByName()`: 名前でのフィルタリング

### ImageExport (`src/api/data/image.ts`)
- ✅ 画像エクスポートの型定義
- ✅ `fromOptions()`: オプションからの生成
- ✅ `fetch()`: 画像エクスポートURL取得
- ✅ `fetchBatch()`: 複数バッチの並列処理

## 実装アプローチ
- **TDD（テスト駆動開発）**: t-wada TDD手法による実装
- **コンパニオンオブジェクトパターン**: TypeScript namespaceを使用した純粋関数の実装
- **イミュータブルデザイン**: 全ての関数が純粋関数として実装

## テスト結果
- ✅ 303個のテストが全て合格
- ✅ TypeScriptビルド成功
- ✅ Lintエラーなし

## 次のステップ
Phase 2.3: 既存のFigmaApiClientクラスの置き換え

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>