### PR TITLE
♻️ [Refactoring]: FigmaApiClientをクラス型から関数型に変換

### DIFF
--- a/src/api/data/component.test.ts
+++ b/src/api/data/component.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { ComponentData } from './component.js';
 import type { FigmaContext } from '../context.js';
 import type { GetComponentsResponse } from '../../types/api/responses/component-responses.js';
+import type { Component } from '../../types/figma-types.js';
 
 describe('ComponentData', () => {
   const mockContext: FigmaContext = {
@@ -51,7 +52,7 @@ describe('ComponentData', () => {
                 backgroundColor: '#F0F0F0',
                 pageName: 'Design System',
               },
-            } as any,
+            } as unknown as Component,
           ],
         },
       };
@@ -81,7 +82,7 @@ describe('ComponentData', () => {
                 backgroundColor: '',
                 pageName: 'Page 1',
               },
-            } as any,
+            } as unknown as Component,
             {
               key: 'comp-2',
               file_key: 'file-1',
@@ -94,7 +95,7 @@ describe('ComponentData', () => {
                 backgroundColor: '',
                 pageName: 'Page 2',
               },
-            } as any,
+            } as unknown as Component,
           ],
         },
       };
@@ -140,7 +141,7 @@ describe('ComponentData', () => {
                 backgroundColor: '#000000',
                 pageName: 'Test Page',
               },
-            } as any,
+            } as unknown as Component,
           ],
         },
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import dotenv from 'dotenv';
 
-import { FigmaApiClient } from './api/figma-api-client.js';
+import { createFigmaApiClient } from './api/figma-api-client.js';
 import { createFileTools } from './tools/file/index.js';
 import { createComponentTools } from './tools/component/index.js';
 import { createStyleTools } from './tools/style/index.js';
@@ -51,7 +51,7 @@ if (!accessToken) {
 }
 
 // APIクライアントの作成
-const apiClient = new FigmaApiClient(accessToken);
+const apiClient = createFigmaApiClient(accessToken);
 
 // ツールの作成
 const fileTools = createFileTools(apiClient);

--- a/src/tools/style/list.test.ts
+++ b/src/tools/style/list.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeAll, afterAll } from 'vitest';
 import { MockFigmaServer } from '../../__tests__/mocks/server.js';
-import { FigmaApiClient } from '../../api/figma-api-client.js';
+import { createFigmaApiClient } from '../../api/figma-api-client.js';
+import type { FigmaApiClient } from '../../api/figma-api-client.js';
 import { TestPorts } from '../../constants/index.js';
 
 describe('get-styles', () => {
@@ -13,7 +14,7 @@ describe('get-styles', () => {
     await mockServer.start();
     
     // APIクライアントを初期化（baseURLを直接指定）
-    apiClient = new FigmaApiClient('test-token', `http://localhost:${TestPorts.STYLE_TEST}`);
+    apiClient = createFigmaApiClient('test-token', `http://localhost:${TestPorts.STYLE_TEST}`);
   });
 
   afterAll(async () => {
@@ -39,7 +40,7 @@ describe('get-styles', () => {
 
   test('APIエラーを適切に処理する', async () => {
     // Arrange - 無効なトークンでクライアントを作成
-    const errorClient = new FigmaApiClient('invalid-token', `http://localhost:${TestPorts.STYLE_TEST}`);
+    const errorClient = createFigmaApiClient('invalid-token', `http://localhost:${TestPorts.STYLE_TEST}`);
     const fileKey = 'test-file-key';
 
     // Act & Assert

--- a/src/tools/version/list.test.ts
+++ b/src/tools/version/list.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeAll, afterAll } from 'vitest';
 import { MockFigmaServer } from '../../__tests__/mocks/server.js';
-import { FigmaApiClient } from '../../api/figma-api-client.js';
+import { createFigmaApiClient } from '../../api/figma-api-client.js';
+import type { FigmaApiClient } from '../../api/figma-api-client.js';
 import { TestPorts } from '../../constants/index.js';
 
 describe('get-versions', () => {
@@ -13,7 +14,7 @@ describe('get-versions', () => {
     await mockServer.start();
 
     // APIクライアントを初期化（baseURLを直接指定）
-    apiClient = new FigmaApiClient('test-token', `http://localhost:${TestPorts.VERSION_TEST}`);
+    apiClient = createFigmaApiClient('test-token', `http://localhost:${TestPorts.VERSION_TEST}`);
   });
 
   afterAll(async () => {
@@ -42,7 +43,7 @@ describe('get-versions', () => {
 
   test('APIエラーを適切に処理する', async () => {
     // Arrange - 無効なトークンでクライアントを作成
-    const errorClient = new FigmaApiClient('invalid-token', `http://localhost:${TestPorts.VERSION_TEST}`);
+    const errorClient = createFigmaApiClient('invalid-token', `http://localhost:${TestPorts.VERSION_TEST}`);
     const fileKey = 'test-file-key';
 
     // Act & Assert


### PR DESCRIPTION
## 📝 概要

implementation-tasks.md のタスク2.3「既存クラスの置き換え」を実装しました。
FigmaApiClientクラスを関数型プログラミングのパターンに変換し、コードベースの一貫性を向上させました。

## 🎯 変更内容

### 1. FigmaApiClientの関数型への変換
- `class FigmaApiClient` → `createFigmaApiClient` 関数
- `FigmaApiClientInterface` インターフェースの定義
- クロージャを使用した内部状態管理の実装

### 2. 後方互換性の確保
- 型エクスポート `export type FigmaApiClient = FigmaApiClientInterface` を追加
- 既存のAPIインターフェースを完全に維持

### 3. 使用箇所の更新
- `src/index.ts`: インスタンス化方法を更新
- `src/tools/style/list.test.ts`: テストコードを更新
- `src/tools/version/list.test.ts`: テストコードを更新

### 4. コード品質の改善
- ESLintエラーの修正（`any` → `unknown as Component`）
- getterメソッドへの型注釈追加

## ✅ チェックリスト

- [x] TypeScriptビルドが成功
- [x] 全テストが合格
- [x] ESLintエラーなし
- [x] 既存の機能に影響なし
- [x] 後方互換性を維持

## 🔍 レビューポイント

1. 関数型への変換が適切に行われているか
2. 内部状態の管理方法が適切か
3. 型定義が正確か
4. テストコードの更新が漏れていないか

## 📊 技術的詳細

**Tidy First原則の適用:**
- 小さく安全なリファクタリング
- 機能の変更なし
- テストグリーンを維持

**パフォーマンス:**
- メモリ使用量に変化なし
- 実行速度に影響なし

## 🚀 今後の作業

- [ ] タスク2.4: 他の使用箇所の更新（必要に応じて）
- [ ] タスク2.5: テストの充実化
- [ ] タスク2.6: 動作確認

---
🤖 Generated with [Claude Code](https://claude.ai/code)