### PR TITLE
♻️ fileツールをコンパニオンオブジェクトパターンにリファクタリング

### DIFF
--- a/src/tools/file/index.ts
+++ b/src/tools/file/index.ts
@@ -1,16 +1,27 @@
 import type { FigmaApiClient } from '../../api/figma-api-client.js';
 import type { FilesApi } from '../../api/endpoints/files.js';
 import type { FileTools } from './types.js';
-import { createGetFileTool } from './info.js';
-import { createGetFileNodesTool } from './nodes.js';
+import { GetFileTool as GetFileToolCompanion, GetFileToolDefinition } from './info.js';
+import { GetFileNodesTool as GetFileNodesToolCompanion, GetFileNodesToolDefinition } from './nodes.js';
 
 export function createFileTools(apiClient: FigmaApiClient): FileTools {
   const filesApi: FilesApi = apiClient.files;
 
+  const getFileTool = GetFileToolCompanion.from(filesApi);
+  const getFileNodesTool = GetFileNodesToolCompanion.from(filesApi);
+
   return {
-    getFile: createGetFileTool(filesApi),
-    getFileNodes: createGetFileNodesTool(filesApi),
+    getFile: {
+      ...GetFileToolDefinition,
+      execute: (args) => GetFileToolCompanion.execute(getFileTool, args),
+    },
+    getFileNodes: {
+      ...GetFileNodesToolDefinition,
+      execute: (args) => GetFileNodesToolCompanion.execute(getFileNodesTool, args),
+    },
   };
 }
 
 export type { FigmaTool, FileTools } from './types.js';
+export { GetFileTool, GetFileToolDefinition } from './info.js';
+export { GetFileNodesTool, GetFileNodesToolDefinition } from './nodes.js';

--- a/src/tools/file/info.test.ts
+++ b/src/tools/file/info.test.ts
@@ -1,18 +1,18 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { createGetFileTool } from './info.js';
+import { GetFileTool, type GetFileTool as GetFileToolType } from './info.js';
 import type { FilesApi } from '../../api/endpoints/files.js';
 import type { FigmaFile } from '../../types/api/responses/index.js';
 
 describe('info tool', () => {
   let filesApi: FilesApi;
-  let get_file: ReturnType<typeof createGetFileTool>;
+  let tool: GetFileToolType;
 
   beforeEach(() => {
     filesApi = {
       getFile: vi.fn(),
       getFileNodes: vi.fn(),
     };
-    get_file = createGetFileTool(filesApi);
+    tool = GetFileTool.from(filesApi);
   });
 
   test('ファイル基本情報を取得できる', async () => {
@@ -38,7 +38,7 @@ describe('info tool', () => {
 
     vi.spyOn(filesApi, 'getFile').mockResolvedValue(mockFile);
 
-    const result = await get_file.execute({
+    const result = await GetFileTool.execute(tool, {
       file_key: 'test-file-key',
     });
 
@@ -80,7 +80,7 @@ describe('info tool', () => {
 
     vi.spyOn(filesApi, 'getFile').mockResolvedValue(mockFile);
 
-    await get_file.execute({
+    await GetFileTool.execute(tool, {
       file_key: 'test-file-key',
       branch_data: true,
     });
@@ -94,7 +94,7 @@ describe('info tool', () => {
     vi.spyOn(filesApi, 'getFile').mockRejectedValue(new Error('API Error'));
 
     await expect(
-      get_file.execute({
+      GetFileTool.execute(tool, {
         file_key: 'test-file-key',
       })
     ).rejects.toThrow('API Error');

--- a/src/tools/file/info.ts
+++ b/src/tools/file/info.ts
@@ -1,48 +1,73 @@
 import type { GetFileOptions } from '../../types/index.js';
 import type { FilesApi } from '../../api/endpoints/files.js';
-import type { GetFileTool, FileResponse } from './types.js';
-import type { ToolDefinition } from '../types.js';
+import type { FileResponse } from './types.js';
+import type { McpToolDefinition } from '../types.js';
 import { GetFileArgsSchema, type GetFileArgs } from './get-file-args.js';
 import { JsonSchema } from '../types.js';
 
-export function createGetFileTool(
-  filesApi: FilesApi
-): GetFileTool & ToolDefinition<GetFileArgs, FileResponse> {
-  return {
-    name: 'get_file',
-    description: 'Get Figma file information including metadata and structure',
-    inputSchema: JsonSchema.from(GetFileArgsSchema),
-    execute: async (args: GetFileArgs): Promise<FileResponse> => {
-      const options: GetFileOptions = {
-        branchData: args.branch_data,
-        version: args.version,
-        pluginData: args.plugin_data,
-      };
+/**
+ * GetFileツールの定義（定数オブジェクト）
+ */
+export const GetFileToolDefinition = {
+  name: 'get_file' as const,
+  description: 'Get Figma file information including metadata and structure',
+  inputSchema: JsonSchema.from(GetFileArgsSchema),
+} as const satisfies McpToolDefinition;
 
-      // Remove undefined values
-      Object.keys(options).forEach((key) => {
-        if (options[key as keyof GetFileOptions] === undefined) {
-          delete options[key as keyof GetFileOptions];
-        }
-      });
-
-      const file = await filesApi.getFile(args.file_key, options);
-      const documentChildren = file.document.children || [];
-      const pagesCount = documentChildren.filter(
-        (child) => 'type' in child && child.type === 'CANVAS'
-      ).length;
-
-      return {
-        name: file.name,
-        lastModified: file.lastModified,
-        editorType: file.editorType,
-        thumbnailUrl: file.thumbnailUrl,
-        version: file.version,
-        documentName: file.document.name,
-        pagesCount,
-        componentsCount: Object.keys(file.components || {}).length,
-        stylesCount: Object.keys(file.styles || {}).length,
-      };
-    },
-  };
+/**
+ * ツールインスタンス（filesApiを保持）
+ */
+export interface GetFileTool {
+  readonly filesApi: FilesApi;
 }
+
+/**
+ * GetFileツールのコンパニオンオブジェクト（関数群）
+ */
+export const GetFileTool = {
+  /**
+   * filesApiからツールインスタンスを作成
+   */
+  from(filesApi: FilesApi): GetFileTool {
+    return { filesApi };
+  },
+
+  /**
+   * ファイル情報取得を実行
+   */
+  async execute(
+    tool: GetFileTool,
+    args: GetFileArgs
+  ): Promise<FileResponse> {
+    const options: GetFileOptions = {
+      branchData: args.branch_data,
+      version: args.version,
+      pluginData: args.plugin_data,
+    };
+
+    // Remove undefined values
+    Object.keys(options).forEach((key) => {
+      if (options[key as keyof GetFileOptions] === undefined) {
+        delete options[key as keyof GetFileOptions];
+      }
+    });
+
+    const file = await tool.filesApi.getFile(args.file_key, options);
+    const documentChildren = file.document.children || [];
+    const pagesCount = documentChildren.filter(
+      (child) => 'type' in child && child.type === 'CANVAS'
+    ).length;
+
+    return {
+      name: file.name,
+      lastModified: file.lastModified,
+      editorType: file.editorType,
+      thumbnailUrl: file.thumbnailUrl,
+      version: file.version,
+      documentName: file.document.name,
+      pagesCount,
+      componentsCount: Object.keys(file.components || {}).length,
+      stylesCount: Object.keys(file.styles || {}).length,
+    };
+  },
+} as const;

--- a/src/tools/file/nodes.test.ts
+++ b/src/tools/file/nodes.test.ts
@@ -1,19 +1,19 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { createGetFileNodesTool } from './nodes.js';
+import { GetFileNodesTool, type GetFileNodesTool as GetFileNodesToolType } from './nodes.js';
 import type { FilesApi } from '../../api/endpoints/files.js';
 import type { GetFileNodesResponse } from '../../types/api/responses/index.js';
 import { GetFileNodesArgsSchema } from './get-file-nodes-args.js';
 
 describe('nodes tool', () => {
   let filesApi: FilesApi;
-  let get_file_nodes: ReturnType<typeof createGetFileNodesTool>;
+  let tool: GetFileNodesToolType;
 
   beforeEach(() => {
     filesApi = {
       getFile: vi.fn(),
       getFileNodes: vi.fn(),
     };
-    get_file_nodes = createGetFileNodesTool(filesApi);
+    tool = GetFileNodesTool.from(filesApi);
   });
 
   test('指定したノードの情報を取得できる', async () => {
@@ -37,7 +37,7 @@ describe('nodes tool', () => {
 
     vi.spyOn(filesApi, 'getFileNodes').mockResolvedValue(mockResponse);
 
-    const result = await get_file_nodes.execute({
+    const result = await GetFileNodesTool.execute(tool, {
       file_key: 'test-file-key',
       ids: ['1:2'],
     });
@@ -90,7 +90,7 @@ describe('nodes tool', () => {
 
     vi.spyOn(filesApi, 'getFileNodes').mockResolvedValue(mockResponse);
 
-    const result = await get_file_nodes.execute({
+    const result = await GetFileNodesTool.execute(tool, {
       file_key: 'test-file-key',
       ids: ['1:2', '3:4'],
     });
@@ -120,7 +120,7 @@ describe('nodes tool', () => {
 
     vi.spyOn(filesApi, 'getFileNodes').mockResolvedValue(mockResponse);
 
-    await get_file_nodes.execute({
+    await GetFileNodesTool.execute(tool, {
       file_key: 'test-file-key',
       ids: ['1:2'],
       depth: 3,
@@ -149,7 +149,7 @@ describe('nodes tool', () => {
 
     vi.spyOn(filesApi, 'getFileNodes').mockResolvedValue(mockResponse);
 
-    await get_file_nodes.execute({
+    await GetFileNodesTool.execute(tool, {
       file_key: 'test-file-key',
       ids: ['1:2'],
       geometry: 'paths',
@@ -170,7 +170,7 @@ describe('nodes tool', () => {
 
     vi.spyOn(filesApi, 'getFileNodes').mockResolvedValue(mockResponse);
 
-    await get_file_nodes.execute({
+    await GetFileNodesTool.execute(tool, {
       file_key: 'test-file-key',
       ids: ['1:2'],
       geometry: 'points',
@@ -191,7 +191,7 @@ describe('nodes tool', () => {
 
     vi.spyOn(filesApi, 'getFileNodes').mockResolvedValue(mockResponse);
 
-    await get_file_nodes.execute({
+    await GetFileNodesTool.execute(tool, {
       file_key: 'test-file-key',
       ids: ['1:2'],
       depth: 2,

--- a/src/tools/file/nodes.ts
+++ b/src/tools/file/nodes.ts
@@ -1,46 +1,71 @@
 import type { GetFileOptions } from '../../types/index.js';
 import type { FilesApi } from '../../api/endpoints/files.js';
-import type { GetFileNodesTool, NodeEntry, FileNodesResponse } from './types.js';
-import type { ToolDefinition } from '../types.js';
+import type { NodeEntry, FileNodesResponse } from './types.js';
+import type { McpToolDefinition } from '../types.js';
 import { GetFileNodesArgsSchema, type GetFileNodesArgs } from './get-file-nodes-args.js';
 import { JsonSchema } from '../types.js';
 
-export function createGetFileNodesTool(
-  filesApi: FilesApi
-): GetFileNodesTool & ToolDefinition<GetFileNodesArgs, FileNodesResponse> {
-  return {
-    name: 'get_file_nodes',
-    description: 'Get specific nodes from a Figma file with optional depth and geometry',
-    inputSchema: JsonSchema.from(GetFileNodesArgsSchema),
-    execute: async (args: GetFileNodesArgs): Promise<FileNodesResponse> => {
-      const options: GetFileOptions = {
-        depth: args.depth,
-        geometry: args.geometry,
-        branchData: args.branch_data,
-        version: args.version,
-        pluginData: args.plugin_data,
-      };
+/**
+ * GetFileNodesツールの定義（定数オブジェクト）
+ */
+export const GetFileNodesToolDefinition = {
+  name: 'get_file_nodes' as const,
+  description: 'Get specific nodes from a Figma file with optional depth and geometry',
+  inputSchema: JsonSchema.from(GetFileNodesArgsSchema),
+} as const satisfies McpToolDefinition;
 
-      // Remove undefined values
-      Object.keys(options).forEach((key) => {
-        if (options[key as keyof GetFileOptions] === undefined) {
-          delete options[key as keyof GetFileOptions];
-        }
-      });
-
-      const response = await filesApi.getFileNodes(args.file_key, args.ids, options);
-      const nodeEntries = Object.entries(response.nodes || {}) as NodeEntry[];
-      const nodes = nodeEntries.map(([nodeId, nodeData]) => ({
-        ...nodeData.document,
-        id: nodeId,
-      }));
-
-      return {
-        name: response.name,
-        lastModified: response.lastModified,
-        version: response.version,
-        nodes,
-      };
-    },
-  };
+/**
+ * ツールインスタンス（filesApiを保持）
+ */
+export interface GetFileNodesTool {
+  readonly filesApi: FilesApi;
 }
+
+/**
+ * GetFileNodesツールのコンパニオンオブジェクト（関数群）
+ */
+export const GetFileNodesTool = {
+  /**
+   * filesApiからツールインスタンスを作成
+   */
+  from(filesApi: FilesApi): GetFileNodesTool {
+    return { filesApi };
+  },
+
+  /**
+   * ノード情報取得を実行
+   */
+  async execute(
+    tool: GetFileNodesTool,
+    args: GetFileNodesArgs
+  ): Promise<FileNodesResponse> {
+    const options: GetFileOptions = {
+      depth: args.depth,
+      geometry: args.geometry,
+      branchData: args.branch_data,
+      version: args.version,
+      pluginData: args.plugin_data,
+    };
+
+    // Remove undefined values
+    Object.keys(options).forEach((key) => {
+      if (options[key as keyof GetFileOptions] === undefined) {
+        delete options[key as keyof GetFileOptions];
+      }
+    });
+
+    const response = await tool.filesApi.getFileNodes(args.file_key, args.ids, options);
+    const nodeEntries = Object.entries(response.nodes || {}) as NodeEntry[];
+    const nodes = nodeEntries.map(([nodeId, nodeData]) => ({
+      ...nodeData.document,
+      id: nodeId,
+    }));
+
+    return {
+      name: response.name,
+      lastModified: response.lastModified,
+      version: response.version,
+      nodes,
+    };
+  },
+} as const;


### PR DESCRIPTION
## 概要
fileフォルダのツール（GetFileTool、GetFileNodesTool）をファクトリ関数パターンからコンパニオンオブジェクトパターンに変更しました。
これにより、componentフォルダと同じパターンで統一され、コードベース全体の一貫性が向上します。

## 変更内容
- 🔧 `GetFileTool`をコンパニオンオブジェクトパターンに変更
- 🔧 `GetFileNodesTool`をコンパニオンオブジェクトパターンに変更
- ✅ テストファイルを新しいAPIに対応
- 📦 index.tsのエクスポートを更新

## 技術的詳細
### Before（ファクトリ関数パターン）
```typescript
export function createGetFileTool(filesApi: FilesApi): GetFileTool {
  return {
    execute: async (args) => { ... }
  };
}
```

### After（コンパニオンオブジェクトパターン）
```typescript
export interface GetFileTool {
  readonly filesApi: FilesApi;
}

export const GetFileTool = {
  from(filesApi: FilesApi): GetFileTool { ... },
  async execute(tool: GetFileTool, args: GetFileArgs) { ... }
};
```

## テスト
- ✅ 全348テストが成功
- ✅ ESLintチェック合格
- ✅ TypeScriptビルド成功

## レビューポイント
- コンパニオンオブジェクトパターンの実装が適切か
- 型定義が明確で使いやすいか
- componentフォルダとの一貫性が保たれているか

🤖 Generated with [Claude Code](https://claude.ai/code)