### PR TITLE
♻️ fileツールをコンパニオンオブジェクトパターンにリファクタリング

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprot
 import dotenv from 'dotenv';
 
 import { createFigmaApiClient } from './api/figma-api-client.js';
-import { createFileTools } from './tools/file/index.js';
+import { GetFileTool, GetFileToolDefinition, GetFileNodesTool, GetFileNodesToolDefinition } from './tools/file/index.js';
 import { GetComponentsTool, GetComponentsToolDefinition } from './tools/component/index.js';
 import { createStyleTools } from './tools/style/index.js';
 import { createImageTools } from './tools/image/index.js';
@@ -54,7 +54,8 @@ if (!accessToken) {
 const apiClient = createFigmaApiClient(accessToken);
 
 // ツールの作成
-const fileTools = createFileTools(apiClient);
+const getFileTool = GetFileTool.from(apiClient);
+const getFileNodesTool = GetFileNodesTool.from(apiClient);
 const componentTool = GetComponentsTool.from(apiClient);
 const styleTools = createStyleTools(apiClient);
 const imageTools = createImageTools(apiClient);
@@ -65,14 +66,14 @@ server.setRequestHandler(ListToolsRequestSchema, () => {
   return {
     tools: [
       {
-        name: fileTools.getFile.name,
-        description: fileTools.getFile.description,
-        inputSchema: fileTools.getFile.inputSchema,
+        name: GetFileToolDefinition.name,
+        description: GetFileToolDefinition.description,
+        inputSchema: GetFileToolDefinition.inputSchema,
       },
       {
-        name: fileTools.getFileNodes.name,
-        description: fileTools.getFileNodes.description,
-        inputSchema: fileTools.getFileNodes.inputSchema,
+        name: GetFileNodesToolDefinition.name,
+        description: GetFileNodesToolDefinition.description,
+        inputSchema: GetFileNodesToolDefinition.inputSchema,
       },
       {
         name: GetComponentsToolDefinition.name,
@@ -115,7 +116,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     switch (name) {
       case 'get_file': {
         const validatedArgs = GetFileArgsSchema.parse(args);
-        const result = await fileTools.getFile.execute(validatedArgs);
+        const result = await GetFileTool.execute(getFileTool, validatedArgs);
         return {
           content: [
             {
@@ -128,7 +129,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case 'get_file_nodes': {
         const validatedArgs = GetFileNodesArgsSchema.parse(args);
-        const result = await fileTools.getFileNodes.execute(validatedArgs);
+        const result = await GetFileNodesTool.execute(getFileNodesTool, validatedArgs);
         return {
           content: [
             {

--- a/src/tools/file/index.ts
+++ b/src/tools/file/index.ts
@@ -1,27 +1,6 @@
-import type { FigmaApiClient } from '../../api/figma-api-client.js';
-import type { FilesApi } from '../../api/endpoints/files.js';
-import type { FileTools } from './types.js';
-import { GetFileTool as GetFileToolCompanion, GetFileToolDefinition } from './info.js';
-import { GetFileNodesTool as GetFileNodesToolCompanion, GetFileNodesToolDefinition } from './nodes.js';
-
-export function createFileTools(apiClient: FigmaApiClient): FileTools {
-  const filesApi: FilesApi = apiClient.files;
-
-  const getFileTool = GetFileToolCompanion.from(filesApi);
-  const getFileNodesTool = GetFileNodesToolCompanion.from(filesApi);
-
-  return {
-    getFile: {
-      ...GetFileToolDefinition,
-      execute: (args) => GetFileToolCompanion.execute(getFileTool, args),
-    },
-    getFileNodes: {
-      ...GetFileNodesToolDefinition,
-      execute: (args) => GetFileNodesToolCompanion.execute(getFileNodesTool, args),
-    },
-  };
-}
-
-export type { FigmaTool, FileTools } from './types.js';
+// 再エクスポート
 export { GetFileTool, GetFileToolDefinition } from './info.js';
 export { GetFileNodesTool, GetFileNodesToolDefinition } from './nodes.js';
+export type { GetFileArgs } from './get-file-args.js';
+export type { GetFileNodesArgs } from './get-file-nodes-args.js';
+export type { FigmaTool, FileTools, FileResponse, FileNodesResponse } from './types.js';

--- a/src/tools/file/info.test.ts
+++ b/src/tools/file/info.test.ts
@@ -1,18 +1,20 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { GetFileTool, type GetFileTool as GetFileToolType } from './info.js';
-import type { FilesApi } from '../../api/endpoints/files.js';
+import { GetFileTool } from './info.js';
+import type { FigmaApiClient } from '../../api/figma-api-client.js';
 import type { FigmaFile } from '../../types/api/responses/index.js';
 
 describe('info tool', () => {
-  let filesApi: FilesApi;
-  let tool: GetFileToolType;
+  let apiClient: FigmaApiClient;
+  let tool: GetFileTool;
 
   beforeEach(() => {
-    filesApi = {
-      getFile: vi.fn(),
-      getFileNodes: vi.fn(),
-    };
-    tool = GetFileTool.from(filesApi);
+    apiClient = {
+      files: {
+        getFile: vi.fn(),
+        getFileNodes: vi.fn(),
+      },
+    } as unknown as FigmaApiClient;
+    tool = GetFileTool.from(apiClient);
   });
 
   test('ファイル基本情報を取得できる', async () => {
@@ -36,7 +38,7 @@ describe('info tool', () => {
       linkAccess: 'view',
     };
 
-    vi.spyOn(filesApi, 'getFile').mockResolvedValue(mockFile);
+    vi.spyOn(apiClient.files, 'getFile').mockResolvedValue(mockFile);
 
     const result = await GetFileTool.execute(tool, {
       file_key: 'test-file-key',
@@ -54,7 +56,7 @@ describe('info tool', () => {
       stylesCount: 0,
     });
 
-    expect(filesApi.getFile).toHaveBeenCalledWith('test-file-key', {});
+    expect(apiClient.files.getFile).toHaveBeenCalledWith('test-file-key', {});
   });
 
   test('ブランチデータを含めてファイル情報を取得できる', async () => {
@@ -78,20 +80,20 @@ describe('info tool', () => {
       linkAccess: 'view',
     };
 
-    vi.spyOn(filesApi, 'getFile').mockResolvedValue(mockFile);
+    vi.spyOn(apiClient.files, 'getFile').mockResolvedValue(mockFile);
 
     await GetFileTool.execute(tool, {
       file_key: 'test-file-key',
       branch_data: true,
     });
 
-    expect(filesApi.getFile).toHaveBeenCalledWith('test-file-key', {
+    expect(apiClient.files.getFile).toHaveBeenCalledWith('test-file-key', {
       branchData: true,
     });
   });
 
   test('エラーが発生した場合は適切にエラーを返す', async () => {
-    vi.spyOn(filesApi, 'getFile').mockRejectedValue(new Error('API Error'));
+    vi.spyOn(apiClient.files, 'getFile').mockRejectedValue(new Error('API Error'));
 
     await expect(
       GetFileTool.execute(tool, {

--- a/src/tools/file/info.ts
+++ b/src/tools/file/info.ts
@@ -1,5 +1,5 @@
 import type { GetFileOptions } from '../../types/index.js';
-import type { FilesApi } from '../../api/endpoints/files.js';
+import { FigmaApiClient } from '../../api/figma-api-client.js';
 import type { FileResponse } from './types.js';
 import type { McpToolDefinition } from '../types.js';
 import { GetFileArgsSchema, type GetFileArgs } from './get-file-args.js';
@@ -15,10 +15,10 @@ export const GetFileToolDefinition = {
 } as const satisfies McpToolDefinition;
 
 /**
- * ツールインスタンス（filesApiを保持）
+ * ツールインスタンス（apiClientを保持）
  */
 export interface GetFileTool {
-  readonly filesApi: FilesApi;
+  readonly apiClient: FigmaApiClient;
 }
 
 /**
@@ -26,10 +26,10 @@ export interface GetFileTool {
  */
 export const GetFileTool = {
   /**
-   * filesApiからツールインスタンスを作成
+   * apiClientからツールインスタンスを作成
    */
-  from(filesApi: FilesApi): GetFileTool {
-    return { filesApi };
+  from(apiClient: FigmaApiClient): GetFileTool {
+    return { apiClient };
   },
 
   /**
@@ -52,7 +52,7 @@ export const GetFileTool = {
       }
     });
 
-    const file = await tool.filesApi.getFile(args.file_key, options);
+    const file = await tool.apiClient.files.getFile(args.file_key, options);
     const documentChildren = file.document.children || [];
     const pagesCount = documentChildren.filter(
       (child) => 'type' in child && child.type === 'CANVAS'

--- a/src/tools/file/nodes.test.ts
+++ b/src/tools/file/nodes.test.ts
@@ -1,19 +1,21 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { GetFileNodesTool, type GetFileNodesTool as GetFileNodesToolType } from './nodes.js';
-import type { FilesApi } from '../../api/endpoints/files.js';
+import { GetFileNodesTool } from './nodes.js';
+import type { FigmaApiClient } from '../../api/figma-api-client.js';
 import type { GetFileNodesResponse } from '../../types/api/responses/index.js';
 import { GetFileNodesArgsSchema } from './get-file-nodes-args.js';
 
 describe('nodes tool', () => {
-  let filesApi: FilesApi;
-  let tool: GetFileNodesToolType;
+  let apiClient: FigmaApiClient;
+  let tool: GetFileNodesTool;
 
   beforeEach(() => {
-    filesApi = {
-      getFile: vi.fn(),
-      getFileNodes: vi.fn(),
-    };
-    tool = GetFileNodesTool.from(filesApi);
+    apiClient = {
+      files: {
+        getFile: vi.fn(),
+        getFileNodes: vi.fn(),
+      },
+    } as unknown as FigmaApiClient;
+    tool = GetFileNodesTool.from(apiClient);
   });
 
   test('指定したノードの情報を取得できる', async () => {
@@ -35,7 +37,7 @@ describe('nodes tool', () => {
       },
     };
 
-    vi.spyOn(filesApi, 'getFileNodes').mockResolvedValue(mockResponse);
+    vi.spyOn(apiClient.files, 'getFileNodes').mockResolvedValue(mockResponse);
 
     const result = await GetFileNodesTool.execute(tool, {
       file_key: 'test-file-key',
@@ -56,7 +58,7 @@ describe('nodes tool', () => {
       ],
     });
 
-    expect(filesApi.getFileNodes).toHaveBeenCalledWith('test-file-key', ['1:2'], {});
+    expect(apiClient.files.getFileNodes).toHaveBeenCalledWith('test-file-key', ['1:2'], {});
   });
 
   test('複数のノードを取得できる', async () => {
@@ -88,7 +90,7 @@ describe('nodes tool', () => {
       },
     };
 
-    vi.spyOn(filesApi, 'getFileNodes').mockResolvedValue(mockResponse);
+    vi.spyOn(apiClient.files, 'getFileNodes').mockResolvedValue(mockResponse);
 
     const result = await GetFileNodesTool.execute(tool, {
       file_key: 'test-file-key',
@@ -118,7 +120,7 @@ describe('nodes tool', () => {
       nodes: {},
     };
 
-    vi.spyOn(filesApi, 'getFileNodes').mockResolvedValue(mockResponse);
+    vi.spyOn(apiClient.files, 'getFileNodes').mockResolvedValue(mockResponse);
 
     await GetFileNodesTool.execute(tool, {
       file_key: 'test-file-key',
@@ -126,7 +128,7 @@ describe('nodes tool', () => {
       depth: 3,
     });
 
-    expect(filesApi.getFileNodes).toHaveBeenCalledWith('test-file-key', ['1:2'], { depth: 3 });
+    expect(apiClient.files.getFileNodes).toHaveBeenCalledWith('test-file-key', ['1:2'], { depth: 3 });
   });
 
   test('ノードIDが空の場合はエラーになる', () => {
@@ -147,7 +149,7 @@ describe('nodes tool', () => {
       nodes: {},
     };
 
-    vi.spyOn(filesApi, 'getFileNodes').mockResolvedValue(mockResponse);
+    vi.spyOn(apiClient.files, 'getFileNodes').mockResolvedValue(mockResponse);
 
     await GetFileNodesTool.execute(tool, {
       file_key: 'test-file-key',
@@ -155,7 +157,7 @@ describe('nodes tool', () => {
       geometry: 'paths',
     });
 
-    expect(filesApi.getFileNodes).toHaveBeenCalledWith('test-file-key', ['1:2'], {
+    expect(apiClient.files.getFileNodes).toHaveBeenCalledWith('test-file-key', ['1:2'], {
       geometry: 'paths',
     });
   });
@@ -168,7 +170,7 @@ describe('nodes tool', () => {
       nodes: {},
     };
 
-    vi.spyOn(filesApi, 'getFileNodes').mockResolvedValue(mockResponse);
+    vi.spyOn(apiClient.files, 'getFileNodes').mockResolvedValue(mockResponse);
 
     await GetFileNodesTool.execute(tool, {
       file_key: 'test-file-key',
@@ -176,7 +178,7 @@ describe('nodes tool', () => {
       geometry: 'points',
     });
 
-    expect(filesApi.getFileNodes).toHaveBeenCalledWith('test-file-key', ['1:2'], {
+    expect(apiClient.files.getFileNodes).toHaveBeenCalledWith('test-file-key', ['1:2'], {
       geometry: 'points',
     });
   });
@@ -189,7 +191,7 @@ describe('nodes tool', () => {
       nodes: {},
     };
 
-    vi.spyOn(filesApi, 'getFileNodes').mockResolvedValue(mockResponse);
+    vi.spyOn(apiClient.files, 'getFileNodes').mockResolvedValue(mockResponse);
 
     await GetFileNodesTool.execute(tool, {
       file_key: 'test-file-key',
@@ -198,7 +200,7 @@ describe('nodes tool', () => {
       geometry: 'paths',
     });
 
-    expect(filesApi.getFileNodes).toHaveBeenCalledWith('test-file-key', ['1:2'], {
+    expect(apiClient.files.getFileNodes).toHaveBeenCalledWith('test-file-key', ['1:2'], {
       depth: 2,
       geometry: 'paths',
     });

--- a/src/tools/file/nodes.ts
+++ b/src/tools/file/nodes.ts
@@ -1,5 +1,5 @@
 import type { GetFileOptions } from '../../types/index.js';
-import type { FilesApi } from '../../api/endpoints/files.js';
+import { FigmaApiClient } from '../../api/figma-api-client.js';
 import type { NodeEntry, FileNodesResponse } from './types.js';
 import type { McpToolDefinition } from '../types.js';
 import { GetFileNodesArgsSchema, type GetFileNodesArgs } from './get-file-nodes-args.js';
@@ -15,10 +15,10 @@ export const GetFileNodesToolDefinition = {
 } as const satisfies McpToolDefinition;
 
 /**
- * ツールインスタンス（filesApiを保持）
+ * ツールインスタンス（apiClientを保持）
  */
 export interface GetFileNodesTool {
-  readonly filesApi: FilesApi;
+  readonly apiClient: FigmaApiClient;
 }
 
 /**
@@ -26,10 +26,10 @@ export interface GetFileNodesTool {
  */
 export const GetFileNodesTool = {
   /**
-   * filesApiからツールインスタンスを作成
+   * apiClientからツールインスタンスを作成
    */
-  from(filesApi: FilesApi): GetFileNodesTool {
-    return { filesApi };
+  from(apiClient: FigmaApiClient): GetFileNodesTool {
+    return { apiClient };
   },
 
   /**
@@ -54,7 +54,7 @@ export const GetFileNodesTool = {
       }
     });
 
-    const response = await tool.filesApi.getFileNodes(args.file_key, args.ids, options);
+    const response = await tool.apiClient.files.getFileNodes(args.file_key, args.ids, options);
     const nodeEntries = Object.entries(response.nodes || {}) as NodeEntry[];
     const nodes = nodeEntries.map(([nodeId, nodeData]) => ({
       ...nodeData.document,


### PR DESCRIPTION
## 概要
fileフォルダのツール（GetFileTool、GetFileNodesTool）をコンパニオンオブジェクトパターンにリファクタリングしました。これにより、componentフォルダと同じアーキテクチャパターンに統一されました。

## 変更内容
- ✨ GetFileToolとGetFileNodesToolをコンパニオンオブジェクトパターンに変更
- 🗑️ createFileTools関数を削除
- ♻️ 依存関係をFilesApiからFigmaApiClientに変更
- 🚨 テストファイルを新しいAPIに対応

## 変更理由
- コードベース全体での一貫性を保つため
- componentフォルダで採用したパターンに統一
- よりシンプルで理解しやすい構造に

## テスト
- ✅ すべてのテストが成功（348個のテスト）
- ✅ fileフォルダのテスト：10個すべて成功
- ✅ ESLintエラーなし
- ✅ TypeScriptコンパイルエラーなし

## 関連
- PR #36: componentツールのコンパニオンオブジェクトパターンへのリファクタリング

🤖 Generated with [Claude Code](https://claude.ai/code)