### PR TITLE
♻️ imageツールをコンパニオンオブジェクトパターンに変更

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,15 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprot
 import dotenv from 'dotenv';
 
 import { createFigmaApiClient } from './api/figma-api-client.js';
-import { GetFileTool, GetFileToolDefinition, GetFileNodesTool, GetFileNodesToolDefinition } from './tools/file/index.js';
+import {
+  GetFileTool,
+  GetFileToolDefinition,
+  GetFileNodesTool,
+  GetFileNodesToolDefinition,
+} from './tools/file/index.js';
 import { GetComponentsTool, GetComponentsToolDefinition } from './tools/component/index.js';
 import { createStyleTools } from './tools/style/index.js';
-import { createImageTools } from './tools/image/index.js';
+import { ExportImagesTool, ExportImagesToolDefinition } from './tools/image/index.js';
 import { GetCommentsTool, GetCommentsToolDefinition } from './tools/comment/index.js';
 import { createVersionTools } from './tools/version/index.js';
 import { parseFigmaUrlTool, parseFigmaUrl } from './tools/parse-figma-url/index.js';
@@ -58,7 +63,7 @@ const getFileTool = GetFileTool.from(apiClient);
 const getFileNodesTool = GetFileNodesTool.from(apiClient);
 const componentTool = GetComponentsTool.from(apiClient);
 const styleTools = createStyleTools(apiClient);
-const imageTools = createImageTools(apiClient);
+const exportImagesTool = ExportImagesTool.from(apiClient);
 const commentTool = GetCommentsTool.from(apiClient);
 const versionTools = createVersionTools(apiClient);
 
@@ -86,9 +91,9 @@ server.setRequestHandler(ListToolsRequestSchema, () => {
         inputSchema: styleTools.getStyles.inputSchema,
       },
       {
-        name: imageTools.exportImages.name,
-        description: imageTools.exportImages.description,
-        inputSchema: imageTools.exportImages.inputSchema,
+        name: ExportImagesToolDefinition.name,
+        description: ExportImagesToolDefinition.description,
+        inputSchema: ExportImagesToolDefinition.inputSchema,
       },
       {
         name: GetCommentsToolDefinition.name,
@@ -168,7 +173,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case 'export_images': {
         const validatedArgs = ExportImagesArgsSchema.parse(args);
-        const result = await imageTools.exportImages.execute(validatedArgs);
+        const result = await ExportImagesTool.execute(exportImagesTool, validatedArgs);
         return {
           content: [
             {

--- a/src/tools/file/info.ts
+++ b/src/tools/file/info.ts
@@ -1,5 +1,5 @@
 import type { GetFileOptions } from '../../types/index.js';
-import { FigmaApiClient } from '../../api/figma-api-client.js';
+import type { FigmaApiClient } from '../../api/figma-api-client.js';
 import type { FileResponse } from './types.js';
 import type { McpToolDefinition } from '../types.js';
 import { GetFileArgsSchema, type GetFileArgs } from './get-file-args.js';

--- a/src/tools/file/nodes.ts
+++ b/src/tools/file/nodes.ts
@@ -1,5 +1,5 @@
 import type { GetFileOptions } from '../../types/index.js';
-import { FigmaApiClient } from '../../api/figma-api-client.js';
+import type { FigmaApiClient } from '../../api/figma-api-client.js';
 import type { NodeEntry, FileNodesResponse } from './types.js';
 import type { McpToolDefinition } from '../types.js';
 import { GetFileNodesArgsSchema, type GetFileNodesArgs } from './get-file-nodes-args.js';

--- a/src/tools/image/export.test.ts
+++ b/src/tools/image/export.test.ts
@@ -1,18 +1,23 @@
 import { describe, test, expect, beforeAll, afterAll } from 'vitest';
 import { FigmaApiClient } from '../../api/figma-api-client.js';
 import { MockFigmaServer } from '../../__tests__/mocks/server.js';
+import { ExportImagesTool } from './export.js';
 
 describe('export-images', () => {
   let mockServer: MockFigmaServer;
   let apiClient: FigmaApiClient;
+  let exportImagesTool: ExportImagesTool;
 
   beforeAll(async () => {
     // モックサーバーを起動
     mockServer = new MockFigmaServer(3004);
     await mockServer.start();
-    
+
     // 実際のAPIクライアントを作成（モックサーバーに接続）
     apiClient = FigmaApiClient.create('test-token', 'http://localhost:3004');
+
+    // ツールインスタンスを作成
+    exportImagesTool = ExportImagesTool.from(apiClient);
   });
 
   afterAll(async () => {
@@ -27,9 +32,12 @@ describe('export-images', () => {
     const scale = 2;
 
     // Act
-    const { createImageTools } = await import('./index.js');
-    const tools = createImageTools(apiClient);
-    const result = await tools.exportImages.execute({ fileKey, ids, format, scale });
+    const result = await ExportImagesTool.execute(exportImagesTool, {
+      fileKey,
+      ids,
+      format,
+      scale,
+    });
 
     // Assert
     expect(result).toBeDefined();
@@ -45,9 +53,7 @@ describe('export-images', () => {
     const ids = ['1:2'];
 
     // Act
-    const { createImageTools } = await import('./index.js');
-    const tools = createImageTools(apiClient);
-    const result = await tools.exportImages.execute({ fileKey, ids });
+    const result = await ExportImagesTool.execute(exportImagesTool, { fileKey, ids });
 
     // Assert
     expect(result).toBeDefined();
@@ -62,9 +68,7 @@ describe('export-images', () => {
     const format = 'svg';
 
     // Act
-    const { createImageTools } = await import('./index.js');
-    const tools = createImageTools(apiClient);
-    const result = await tools.exportImages.execute({ fileKey, ids, format });
+    const result = await ExportImagesTool.execute(exportImagesTool, { fileKey, ids, format });
 
     // Assert
     expect(result).toBeDefined();
@@ -80,9 +84,7 @@ describe('export-images', () => {
     const scale = 3;
 
     // Act
-    const { createImageTools } = await import('./index.js');
-    const tools = createImageTools(apiClient);
-    const result = await tools.exportImages.execute({ fileKey, ids, scale });
+    const result = await ExportImagesTool.execute(exportImagesTool, { fileKey, ids, scale });
 
     // Assert
     expect(result).toBeDefined();
@@ -102,9 +104,7 @@ describe('export-images', () => {
     };
 
     // Act
-    const { createImageTools } = await import('./index.js');
-    const tools = createImageTools(apiClient);
-    const result = await tools.exportImages.execute({ fileKey, ...options });
+    const result = await ExportImagesTool.execute(exportImagesTool, { fileKey, ...options });
 
     // Assert
     expect(result).toBeDefined();
@@ -121,9 +121,7 @@ describe('export-images', () => {
     const ids = ['non-existent-node'];
 
     // Act
-    const { createImageTools } = await import('./index.js');
-    const tools = createImageTools(apiClient);
-    const result = await tools.exportImages.execute({ fileKey, ids });
+    const result = await ExportImagesTool.execute(exportImagesTool, { fileKey, ids });
 
     // Assert
     expect(result).toBeDefined();

--- a/src/tools/image/export.ts
+++ b/src/tools/image/export.ts
@@ -1,17 +1,40 @@
 import { FigmaApiClient } from '../../api/figma-api-client.js';
-import type { ImageTool } from './types.js';
 import type { ExportImageResponse } from '../../types/api/responses/image-responses.js';
 import { ExportImagesArgsSchema, type ExportImagesArgs } from './export-images-args.js';
-import { JsonSchema } from '../types.js';
+import { JsonSchema, type McpToolDefinition } from '../types.js';
 
-export const createExportImagesTool = (apiClient: FigmaApiClient): ImageTool => {
-  return {
-    name: 'export_images',
-    description: 'Export images from a Figma file',
-    inputSchema: JsonSchema.from(ExportImagesArgsSchema),
-    execute: async (args: ExportImagesArgs): Promise<ExportImageResponse> => {
-      const { fileKey, ...options } = args;
-      return FigmaApiClient.exportImages(apiClient, fileKey, options);
-    },
-  };
-};
+/**
+ * 画像エクスポートツールの定義（定数オブジェクト）
+ */
+export const ExportImagesToolDefinition = {
+  name: 'export_images' as const,
+  description: 'Export images from a Figma file',
+  inputSchema: JsonSchema.from(ExportImagesArgsSchema),
+} as const satisfies McpToolDefinition;
+
+/**
+ * ツールインスタンス（apiClientを保持）
+ */
+export interface ExportImagesTool {
+  readonly apiClient: FigmaApiClient;
+}
+
+/**
+ * 画像エクスポートツールのコンパニオンオブジェクト（関数群）
+ */
+export const ExportImagesTool = {
+  /**
+   * apiClientからツールインスタンスを作成
+   */
+  from(apiClient: FigmaApiClient): ExportImagesTool {
+    return { apiClient };
+  },
+
+  /**
+   * 画像エクスポートを実行
+   */
+  async execute(tool: ExportImagesTool, args: ExportImagesArgs): Promise<ExportImageResponse> {
+    const { fileKey, ...options } = args;
+    return FigmaApiClient.exportImages(tool.apiClient, fileKey, options);
+  },
+} as const;

--- a/src/tools/image/index.ts
+++ b/src/tools/image/index.ts
@@ -1,13 +1,3 @@
-import type { FigmaApiClient } from '../../api/figma-api-client.js';
-import { createExportImagesTool } from './export.js';
-import type { ImageTool } from './types.js';
-
-interface ImageTools {
-  exportImages: ImageTool;
-}
-
-export const createImageTools = (apiClient: FigmaApiClient): ImageTools => {
-  return {
-    exportImages: createExportImagesTool(apiClient),
-  };
-};
+// 再エクスポート
+export { ExportImagesTool, ExportImagesToolDefinition } from './export.js';
+export type { ExportImagesArgs } from './export-images-args.js';

--- a/src/tools/image/types.ts
+++ b/src/tools/image/types.ts
@@ -1,9 +1,0 @@
-import type { ToolDefinition } from '../types.js';
-import type { ExportImageResponse } from '../../types/api/responses/image-responses.js';
-import type { ExportImagesArgs } from './export-images-args.js';
-
-export interface ImageTool extends ToolDefinition<ExportImagesArgs, ExportImageResponse> {
-  name: string;
-  description: string;
-  execute: (args: ExportImagesArgs) => Promise<ExportImageResponse>;
-}


### PR DESCRIPTION
## 概要
imageツールの構造をcommentツールと同様のコンパニオンオブジェクトパターンに変更しました。

## 変更内容

### 1. ツール構造の変更
- `createExportImagesTool`関数を廃止
- `ExportImagesToolDefinition`で定数定義を分離
- `ExportImagesTool`コンパニオンオブジェクトで関数群を定義
- `index.ts`を再エクスポート形式に変更

### 2. ファイル構成の変更
- `src/tools/image/export.ts` - コンパニオンオブジェクトパターンに変更
- `src/tools/image/index.ts` - 再エクスポート形式に変更
- `src/tools/image/types.ts` - 削除（不要になったため）

### 3. テストとメインコードの更新
- テストファイルを新しい構造に対応
- `src/index.ts`で新しいツール構造を使用

### 4. Lint修正
- fileツールのインポートをtype-onlyに修正（ESLint準拠）

## メリット
- commentツールと一貫性のある構造
- より明確な責任の分離
- 定数定義と実装の分離による保守性向上

## テスト
✅ すべてのテストが成功
✅ ビルドが正常に完了
✅ Lintチェックをパス

🤖 Generated with [Claude Code](https://claude.ai/code)