### PR TITLE
♻️ parse-figma-urlツールをコンパニオンオブジェクトパターンに変更

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import { createStyleTools } from './tools/style/index.js';
 import { ExportImagesTool, ExportImagesToolDefinition } from './tools/image/index.js';
 import { GetCommentsTool, GetCommentsToolDefinition } from './tools/comment/index.js';
 import { createVersionTools } from './tools/version/index.js';
-import { parseFigmaUrlTool, parseFigmaUrl } from './tools/parse-figma-url/index.js';
+import { ParseFigmaUrlTool, ParseFigmaUrlToolDefinition } from './tools/parse-figma-url/index.js';
 import { Logger, LogLevel } from './utils/logger/index.js';
 
 import { GetFileArgsSchema } from './tools/file/get-file-args.js';
@@ -25,7 +25,7 @@ import { GetStylesArgsSchema } from './tools/style/get-styles-args.js';
 import { ExportImagesArgsSchema } from './tools/image/export-images-args.js';
 import { GetCommentsArgsSchema } from './tools/comment/get-comments-args.js';
 import { GetVersionsArgsSchema } from './tools/version/get-versions-args.js';
-import { parseFigmaUrlArgsSchema } from './tools/parse-figma-url/parse-figma-url-args.js';
+import { ParseFigmaUrlArgsSchema } from './tools/parse-figma-url/parse-figma-url-args.js';
 
 dotenv.config();
 
@@ -66,6 +66,7 @@ const styleTools = createStyleTools(apiClient);
 const exportImagesTool = ExportImagesTool.from(apiClient);
 const commentTool = GetCommentsTool.from(apiClient);
 const versionTools = createVersionTools(apiClient);
+const parseFigmaUrlTool = ParseFigmaUrlTool.create();
 
 server.setRequestHandler(ListToolsRequestSchema, () => {
   return {
@@ -106,9 +107,9 @@ server.setRequestHandler(ListToolsRequestSchema, () => {
         inputSchema: versionTools.getVersions.inputSchema,
       },
       {
-        name: parseFigmaUrlTool.name,
-        description: parseFigmaUrlTool.description,
-        inputSchema: parseFigmaUrlTool.inputSchema,
+        name: ParseFigmaUrlToolDefinition.name,
+        description: ParseFigmaUrlToolDefinition.description,
+        inputSchema: ParseFigmaUrlToolDefinition.inputSchema,
       },
     ],
   };
@@ -211,8 +212,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'parse_figma_url': {
-        const validatedArgs = parseFigmaUrlArgsSchema.parse(args);
-        const result = parseFigmaUrl(validatedArgs);
+        const validatedArgs = ParseFigmaUrlArgsSchema.parse(args);
+        const result = ParseFigmaUrlTool.execute(parseFigmaUrlTool, validatedArgs);
         return {
           content: [
             {

--- a/src/tools/parse-figma-url/index.ts
+++ b/src/tools/parse-figma-url/index.ts
@@ -1,19 +1,3 @@
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
-import { parseFigmaUrl } from './parse-figma-url.js';
-
-export const parseFigmaUrlTool: Tool = {
-  name: 'parse_figma_url',
-  description: 'Parse a Figma URL to extract file ID, file name, and node ID, then save to local storage',
-  inputSchema: {
-    type: 'object',
-    properties: {
-      url: {
-        type: 'string',
-        description: 'Figma URL to parse (e.g., https://www.figma.com/file/ABC123xyz/My-Design-File?node-id=1234-5678)',
-      },
-    },
-    required: ['url'],
-  },
-};
-
-export { parseFigmaUrl };
+// 再エクスポート
+export { ParseFigmaUrlTool, ParseFigmaUrlToolDefinition } from './parse-figma-url.js';
+export type { ParseFigmaUrlArgs } from './parse-figma-url-args.js';

--- a/src/tools/parse-figma-url/parse-figma-url-args.ts
+++ b/src/tools/parse-figma-url/parse-figma-url-args.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
-export const parseFigmaUrlArgsSchema = z.object({
+export const ParseFigmaUrlArgsSchema = z.object({
   url: z.string().describe('Figma URL to parse (e.g., https://www.figma.com/file/ABC123xyz/My-Design-File?node-id=1234-5678)'),
 });
 
-export type ParseFigmaUrlArgs = z.infer<typeof parseFigmaUrlArgsSchema>;
+export type ParseFigmaUrlArgs = z.infer<typeof ParseFigmaUrlArgsSchema>;

--- a/src/tools/parse-figma-url/parse-figma-url.test.ts
+++ b/src/tools/parse-figma-url/parse-figma-url.test.ts
@@ -1,20 +1,23 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest';
-import { parseFigmaUrl } from './parse-figma-url.js';
+import { ParseFigmaUrlTool } from './parse-figma-url.js';
 import * as runtimeConfig from '../../config/runtime-config.js';
 
 // runtime-configをモック化
 vi.mock('../../config/runtime-config.js');
 
-describe('parseFigmaUrl tool', () => {
+describe('ParseFigmaUrlTool', () => {
+  let tool: ReturnType<typeof ParseFigmaUrlTool.create>;
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(runtimeConfig.setRuntimeConfig).mockImplementation(() => {});
+    tool = ParseFigmaUrlTool.create();
   });
 
   test('有効なファイルURLをパースして保存できる', () => {
     const url = 'https://www.figma.com/file/ABC123xyz/My-Design-File?node-id=1234-5678';
     
-    const result = parseFigmaUrl({ url });
+    const result = ParseFigmaUrlTool.execute(tool, { url });
 
     // 正しい結果を返すことを確認
     expect(result).toEqual({
@@ -39,7 +42,7 @@ describe('parseFigmaUrl tool', () => {
   test('有効なデザインURLをパースして保存できる', () => {
     const url = 'https://www.figma.com/design/XYZ789abc/Another-Design';
     
-    const result = parseFigmaUrl({ url });
+    const result = ParseFigmaUrlTool.execute(tool, { url });
 
     expect(result).toEqual({
       figmaInfo: {
@@ -54,7 +57,7 @@ describe('parseFigmaUrl tool', () => {
   test('ファイル名なしのURLも処理できる', () => {
     const url = 'https://www.figma.com/file/ABC123xyz';
     
-    const result = parseFigmaUrl({ url });
+    const result = ParseFigmaUrlTool.execute(tool, { url });
 
     expect(result).toEqual({
       figmaInfo: {
@@ -69,18 +72,18 @@ describe('parseFigmaUrl tool', () => {
   test('無効なURLの場合はエラーを返す', () => {
     const url = 'not-a-url';
     
-    expect(() => parseFigmaUrl({ url })).toThrow('Invalid URL');
+    expect(() => ParseFigmaUrlTool.execute(tool, { url })).toThrow('Invalid URL');
   });
 
   test('Figma以外のURLの場合はエラーを返す', () => {
     const url = 'https://example.com/file/ABC123xyz';
     
-    expect(() => parseFigmaUrl({ url })).toThrow('Not a Figma URL');
+    expect(() => ParseFigmaUrlTool.execute(tool, { url })).toThrow('Not a Figma URL');
   });
 
   test('サポートされていないFigmaのURLパターンの場合はエラーを返す', () => {
     const url = 'https://www.figma.com/proto/ABC123xyz/Prototype';
     
-    expect(() => parseFigmaUrl({ url })).toThrow('Unsupported Figma URL pattern');
+    expect(() => ParseFigmaUrlTool.execute(tool, { url })).toThrow('Unsupported Figma URL pattern');
   });
 });

--- a/src/tools/parse-figma-url/parse-figma-url.ts
+++ b/src/tools/parse-figma-url/parse-figma-url.ts
@@ -1,7 +1,26 @@
 import { parseFigmaUrl as parseUrl } from '../../utils/figma-url-parser.js';
 import { setRuntimeConfig } from '../../config/runtime-config.js';
-import type { ParseFigmaUrlArgs } from './parse-figma-url-args.js';
+import { ParseFigmaUrlArgsSchema, type ParseFigmaUrlArgs } from './parse-figma-url-args.js';
+import { JsonSchema, type McpToolDefinition } from '../types.js';
 
+/**
+ * ParseFigmaURLツールの定義（定数オブジェクト）
+ */
+export const ParseFigmaUrlToolDefinition = {
+  name: 'parse_figma_url' as const,
+  description:
+    'Parse a Figma URL to extract file ID, file name, and node ID, then save to local storage',
+  inputSchema: JsonSchema.from(ParseFigmaUrlArgsSchema),
+} as const satisfies McpToolDefinition;
+
+/**
+ * ツールインスタンス（状態なし）
+ */
+export interface ParseFigmaUrlTool {}
+
+/**
+ * ParseFigmaURLの結果型
+ */
 interface ParseFigmaUrlResult {
   figmaInfo: {
     fileId: string;
@@ -11,17 +30,32 @@ interface ParseFigmaUrlResult {
   message: string;
 }
 
-export function parseFigmaUrl(args: ParseFigmaUrlArgs): ParseFigmaUrlResult {
-  const { url } = args;
-  
-  // URLをパース
-  const figmaInfo = parseUrl(url);
-  
-  // runtime-configに保存
-  setRuntimeConfig({ figmaInfo });
-  
-  return {
-    figmaInfo,
-    message: 'Figma URL parsed and saved successfully',
-  };
-}
+/**
+ * ParseFigmaURLツールのコンパニオンオブジェクト（関数群）
+ */
+export const ParseFigmaUrlTool = {
+  /**
+   * ツールインスタンスを作成
+   */
+  create(): ParseFigmaUrlTool {
+    return {};
+  },
+
+  /**
+   * Figma URLをパースして保存
+   */
+  execute(_tool: ParseFigmaUrlTool, args: ParseFigmaUrlArgs): ParseFigmaUrlResult {
+    const { url } = args;
+
+    // URLをパース
+    const figmaInfo = parseUrl(url);
+
+    // runtime-configに保存
+    setRuntimeConfig({ figmaInfo });
+
+    return {
+      figmaInfo,
+      message: 'Figma URL parsed and saved successfully',
+    };
+  },
+} as const;


### PR DESCRIPTION
## 概要
parse-figma-urlツールをコンパニオンオブジェクトパターンに変更しました。これにより、他のツール（image、comment、fileなど）と同じ構造になり、コードの一貫性が向上しました。

## 変更内容
- ✅ `ParseFigmaUrlToolDefinition`（定数オブジェクト）を追加
- ✅ `ParseFigmaUrlTool`インターフェースとコンパニオンオブジェクトを実装
- ✅ スキーマ名を`ParseFigmaUrlArgsSchema`に変更（大文字始まり）
- ✅ テストをコンパニオンオブジェクトパターンに対応
- ✅ メインのindex.tsでの使用箇所を更新

## コンパニオンオブジェクトパターンの構成
```typescript
// 定数オブジェクト（ツール定義）
export const ParseFigmaUrlToolDefinition = { ... }

// インターフェース（ツールインスタンス）
export interface ParseFigmaUrlTool {}

// コンパニオンオブジェクト（関数群）
export const ParseFigmaUrlTool = {
  create(): ParseFigmaUrlTool { ... },
  execute(tool, args): ParseFigmaUrlResult { ... }
}
```

## テスト
- ✅ すべてのテストが通過
- ✅ ビルド成功
- ✅ ESLintチェック通過

## 関連Issue
なし

🤖 Generated with [Claude Code](https://claude.ai/code)