### PR TITLE
♻️ versionツールをコンパニオンオブジェクトパターンに変更

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { GetComponentsTool, GetComponentsToolDefinition } from './tools/componen
 import { GetStylesTool, GetStylesToolDefinition } from './tools/style/index.js';
 import { ExportImagesTool, ExportImagesToolDefinition } from './tools/image/index.js';
 import { GetCommentsTool, GetCommentsToolDefinition } from './tools/comment/index.js';
-import { createVersionTools } from './tools/version/index.js';
+import { GetVersionsTool, GetVersionsToolDefinition } from './tools/version/index.js';
 import { ParseFigmaUrlTool, ParseFigmaUrlToolDefinition } from './tools/parse-figma-url/index.js';
 import { Logger, LogLevel } from './utils/logger/index.js';
 
@@ -65,7 +65,7 @@ const componentTool = GetComponentsTool.from(apiClient);
 const getStylesTool = GetStylesTool.from(apiClient);
 const exportImagesTool = ExportImagesTool.from(apiClient);
 const commentTool = GetCommentsTool.from(apiClient);
-const versionTools = createVersionTools(apiClient);
+const getVersionsTool = GetVersionsTool.from(apiClient);
 const parseFigmaUrlTool = ParseFigmaUrlTool.create();
 
 server.setRequestHandler(ListToolsRequestSchema, () => {
@@ -102,9 +102,9 @@ server.setRequestHandler(ListToolsRequestSchema, () => {
         inputSchema: GetCommentsToolDefinition.inputSchema,
       },
       {
-        name: versionTools.getVersions.name,
-        description: versionTools.getVersions.description,
-        inputSchema: versionTools.getVersions.inputSchema,
+        name: GetVersionsToolDefinition.name,
+        description: GetVersionsToolDefinition.description,
+        inputSchema: GetVersionsToolDefinition.inputSchema,
       },
       {
         name: ParseFigmaUrlToolDefinition.name,
@@ -200,7 +200,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case 'get_versions': {
         const validatedArgs = GetVersionsArgsSchema.parse(args);
-        const result = await versionTools.getVersions.execute(validatedArgs);
+        const result = await GetVersionsTool.execute(getVersionsTool, validatedArgs);
         return {
           content: [
             {

--- a/src/models/version/__tests__/version-analyze.test.ts
+++ b/src/models/version/__tests__/version-analyze.test.ts
@@ -1,0 +1,79 @@
+import { test, expect } from 'vitest';
+import { Version } from '../version.js';
+import { createMockVersion, createMockVersions } from './version-test-helpers.js';
+
+test('Version.analyze: バージョンを分析', () => {
+  const versions = createMockVersions(6);
+  const analysis = Version.analyze(versions);
+
+  expect(analysis.totalVersions).toBe(6);
+  expect(analysis.mostActiveUser).toBeDefined();
+  expect(analysis.versionsByUser).toBeDefined();
+  expect(Object.keys(analysis.versionsByUser)).toHaveLength(3);
+  expect(analysis.averageTimeBetweenVersions).toBeGreaterThan(0);
+});
+
+test('Version.analyze: 空配列で適切なデフォルト値を返す', () => {
+  const analysis = Version.analyze([]);
+
+  expect(analysis).toEqual({
+    totalVersions: 0,
+    mostActiveUser: null,
+    versionsByUser: {},
+    averageTimeBetweenVersions: 0,
+    majorChanges: [],
+  });
+});
+
+test('Version.analyze: 単一バージョンの場合', () => {
+  const version = createMockVersion('v1', '2024-01-01T00:00:00Z');
+  const analysis = Version.analyze([version]);
+
+  expect(analysis.totalVersions).toBe(1);
+  expect(analysis.mostActiveUser).toBe('user-1');
+  expect(analysis.versionsByUser).toEqual({ 'user-1': 1 });
+  expect(analysis.averageTimeBetweenVersions).toBe(0);
+});
+
+test('Version.analyze: 大きな変更があったバージョンを特定', () => {
+  const versions = [
+    { ...createMockVersion('v1', '2024-01-01T00:00:00Z'), componentsChanged: 5 },
+    { ...createMockVersion('v2', '2024-01-02T00:00:00Z'), componentsChanged: 15 },
+    { ...createMockVersion('v3', '2024-01-03T00:00:00Z'), stylesChanged: 12 },
+    { ...createMockVersion('v4', '2024-01-04T00:00:00Z'), componentsChanged: 3, stylesChanged: 2 },
+  ];
+
+  const analysis = Version.analyze(versions);
+
+  expect(analysis.majorChanges).toHaveLength(2);
+  expect(analysis.majorChanges.map(v => v.id)).toEqual(['v2', 'v3']);
+});
+
+test('Version.analyze: 最もアクティブなユーザーを特定', () => {
+  const versions = [
+    createMockVersion('v1', '2024-01-01T00:00:00Z', '', '', 'user-1'),
+    createMockVersion('v2', '2024-01-02T00:00:00Z', '', '', 'user-1'),
+    createMockVersion('v3', '2024-01-03T00:00:00Z', '', '', 'user-2'),
+    createMockVersion('v4', '2024-01-04T00:00:00Z', '', '', 'user-1'),
+  ];
+
+  const analysis = Version.analyze(versions);
+
+  expect(analysis.mostActiveUser).toBe('user-1');
+  expect(analysis.versionsByUser['user-1']).toBe(3);
+  expect(analysis.versionsByUser['user-2']).toBe(1);
+});
+
+test('Version.analyze: バージョン間の平均時間を計算', () => {
+  const versions = [
+    createMockVersion('v1', '2024-01-01T00:00:00Z'),
+    createMockVersion('v2', '2024-01-02T00:00:00Z'), // 1日後
+    createMockVersion('v3', '2024-01-04T00:00:00Z'), // 2日後
+  ];
+
+  const analysis = Version.analyze(versions);
+
+  // 平均は1.5日（ミリ秒）
+  const expectedAverage = 1.5 * 24 * 60 * 60 * 1000;
+  expect(analysis.averageTimeBetweenVersions).toBe(expectedAverage);
+});

--- a/src/models/version/__tests__/version-filter.test.ts
+++ b/src/models/version/__tests__/version-filter.test.ts
@@ -1,0 +1,82 @@
+import { test, expect } from 'vitest';
+import { Version } from '../version.js';
+import { createMockVersion, createMockVersions } from './version-test-helpers.js';
+
+test('Version.filterByDateRange: 指定期間内のバージョンをフィルタリング', () => {
+  const versions = [
+    createMockVersion('v1', '2024-01-01T00:00:00Z'),
+    createMockVersion('v2', '2024-02-01T00:00:00Z'),
+    createMockVersion('v3', '2024-03-01T00:00:00Z'),
+  ];
+
+  const startDate = new Date('2024-01-15');
+  const endDate = new Date('2024-02-15');
+
+  const filtered = Version.filterByDateRange(versions, startDate, endDate);
+
+  expect(filtered).toHaveLength(1);
+  expect(filtered[0].id).toBe('v2');
+});
+
+test('Version.filterByDateRange: 開始日のみ指定した場合', () => {
+  const versions = createMockVersions(3);
+  const startDate = new Date('2024-01-02');
+
+  const filtered = Version.filterByDateRange(versions, startDate);
+
+  expect(filtered).toHaveLength(2);
+  expect(filtered[0].id).toBe('version-2');
+  expect(filtered[1].id).toBe('version-3');
+});
+
+test('Version.filterByDateRange: 終了日のみ指定した場合', () => {
+  const versions = createMockVersions(3);
+  const endDate = new Date('2024-01-02');
+
+  const filtered = Version.filterByDateRange(versions, undefined, endDate);
+
+  expect(filtered).toHaveLength(2);
+  expect(filtered[0].id).toBe('version-1');
+  expect(filtered[1].id).toBe('version-2');
+});
+
+test('Version.filterByDateRange: 日付指定なしの場合は全て返す', () => {
+  const versions = createMockVersions(3);
+
+  const filtered = Version.filterByDateRange(versions);
+
+  expect(filtered).toHaveLength(3);
+  expect(filtered).toEqual(versions);
+});
+
+test('Version.filterByUser: 特定ユーザーのバージョンをフィルタリング', () => {
+  const versions = createMockVersions(6); // user-1, user-2, user-3が2回ずつ
+
+  const filtered = Version.filterByUser(versions, 'user-1');
+
+  expect(filtered).toHaveLength(2);
+  expect(filtered.every(v => v.user.id === 'user-1')).toBe(true);
+});
+
+test('Version.filterByUser: 存在しないユーザーの場合は空配列', () => {
+  const versions = createMockVersions(3);
+
+  const filtered = Version.filterByUser(versions, 'non-existent-user');
+
+  expect(filtered).toHaveLength(0);
+});
+
+test('Version.getLabeled: ラベル付きバージョンのみ取得', () => {
+  const versions = [
+    createMockVersion('v1', '2024-01-01T00:00:00Z', 'Release v1.0'),
+    createMockVersion('v2', '2024-01-02T00:00:00Z', ''),
+    createMockVersion('v3', '2024-01-03T00:00:00Z', 'Hotfix'),
+    createMockVersion('v4', '2024-01-04T00:00:00Z', '   '), // 空白のみ
+  ];
+
+  const labeled = Version.getLabeled(versions);
+
+  expect(labeled).toHaveLength(2);
+  expect(labeled[0].id).toBe('v1');
+  expect(labeled[1].id).toBe('v3');
+});

--- a/src/models/version/__tests__/version-sort.test.ts
+++ b/src/models/version/__tests__/version-sort.test.ts
@@ -1,0 +1,79 @@
+import { test, expect } from 'vitest';
+import { Version } from '../version.js';
+import { createMockVersion } from './version-test-helpers.js';
+
+test('Version.getLatest: 最新のバージョンを取得', () => {
+  const versions = [
+    createMockVersion('v1', '2024-01-01T00:00:00Z'),
+    createMockVersion('v3', '2024-03-01T00:00:00Z'),
+    createMockVersion('v2', '2024-02-01T00:00:00Z'),
+  ];
+
+  const latest = Version.getLatest(versions);
+
+  expect(latest).toBeDefined();
+  expect(latest?.id).toBe('v3');
+});
+
+test('Version.getLatest: 空配列の場合はnullを返す', () => {
+  const latest = Version.getLatest([]);
+
+  expect(latest).toBeNull();
+});
+
+test('Version.getLatest: 単一要素の場合はその要素を返す', () => {
+  const version = createMockVersion('v1', '2024-01-01T00:00:00Z');
+  const latest = Version.getLatest([version]);
+
+  expect(latest).toBe(version);
+});
+
+test('Version.sortByDate: 新しい順にソート（デフォルト）', () => {
+  const versions = [
+    createMockVersion('v1', '2024-01-01T00:00:00Z'),
+    createMockVersion('v3', '2024-03-01T00:00:00Z'),
+    createMockVersion('v2', '2024-02-01T00:00:00Z'),
+  ];
+
+  const sorted = Version.sortByDate(versions);
+
+  expect(sorted[0].id).toBe('v3');
+  expect(sorted[1].id).toBe('v2');
+  expect(sorted[2].id).toBe('v1');
+  // 元の配列は変更されない
+  expect(versions[0].id).toBe('v1');
+});
+
+test('Version.sortByDate: 古い順にソート', () => {
+  const versions = [
+    createMockVersion('v1', '2024-01-01T00:00:00Z'),
+    createMockVersion('v3', '2024-03-01T00:00:00Z'),
+    createMockVersion('v2', '2024-02-01T00:00:00Z'),
+  ];
+
+  const sorted = Version.sortByDate(versions, true);
+
+  expect(sorted[0].id).toBe('v1');
+  expect(sorted[1].id).toBe('v2');
+  expect(sorted[2].id).toBe('v3');
+});
+
+test('Version.sortByDate: 空配列の場合', () => {
+  const sorted = Version.sortByDate([]);
+
+  expect(sorted).toEqual([]);
+});
+
+test('Version.sortByDate: 同じ日時のバージョンの場合', () => {
+  const sameDate = '2024-01-01T00:00:00Z';
+  const versions = [
+    createMockVersion('v1', sameDate),
+    createMockVersion('v2', sameDate),
+    createMockVersion('v3', sameDate),
+  ];
+
+  const sorted = Version.sortByDate(versions);
+
+  expect(sorted).toHaveLength(3);
+  // 同じ日時の場合、元の順序が保持される（stable sort）
+});

--- a/src/models/version/__tests__/version-test-helpers.ts
+++ b/src/models/version/__tests__/version-test-helpers.ts
@@ -1,0 +1,57 @@
+import type { Version } from '../version.js';
+import type { FigmaUser } from '../../../types/figma-types.js';
+
+/**
+ * テスト用のモックVersionを作成するヘルパー関数
+ */
+export function createMockVersion(
+  id: string,
+  createdAt: string,
+  label = '',
+  description = '',
+  userId = 'user-1'
+): Version {
+  const user: FigmaUser = {
+    id: userId,
+    handle: `user-${userId}`,
+    imgUrl: `https://example.com/avatar/${userId}.png`,
+    email: `${userId}@example.com`,
+  };
+
+  return {
+    id,
+    createdAt,
+    label,
+    description,
+    user,
+    thumbnailUrl: `https://example.com/thumbnail/${id}.png`,
+    pagesChanged: [],
+    componentsChanged: 0,
+    stylesChanged: 0,
+  };
+}
+
+/**
+ * 複数のモックVersionを作成
+ */
+export function createMockVersions(count: number): Version[] {
+  const versions: Version[] = [];
+  const baseDate = new Date('2024-01-01');
+
+  for (let i = 0; i < count; i++) {
+    const date = new Date(baseDate);
+    date.setDate(date.getDate() + i);
+    
+    versions.push(
+      createMockVersion(
+        `version-${i + 1}`,
+        date.toISOString(),
+        i % 2 === 0 ? `Label ${i + 1}` : '',
+        `Description for version ${i + 1}`,
+        `user-${(i % 3) + 1}` // 3人のユーザーをローテーション
+      )
+    );
+  }
+
+  return versions;
+}

--- a/src/models/version/__tests__/version-utils.test.ts
+++ b/src/models/version/__tests__/version-utils.test.ts
@@ -1,0 +1,106 @@
+import { test, expect } from 'vitest';
+import { Version } from '../version.js';
+import { createMockVersion } from './version-test-helpers.js';
+
+test('Version.compare: 2つのバージョン間の変更を比較', () => {
+  const fromVersion = {
+    ...createMockVersion('v1', '2024-01-01T00:00:00Z'),
+    pagesChanged: ['page1', 'page2'],
+    componentsChanged: 5,
+    stylesChanged: 3,
+  };
+
+  const toVersion = {
+    ...createMockVersion('v2', '2024-01-02T00:00:00Z'),
+    pagesChanged: ['page2', 'page3'],
+    componentsChanged: 8,
+    stylesChanged: 2,
+  };
+
+  const comparison = Version.compare(fromVersion, toVersion);
+
+  expect(comparison.from).toBe('v1');
+  expect(comparison.to).toBe('v2');
+  expect(comparison.changes.pagesAdded).toEqual(['page3']);
+  expect(comparison.changes.pagesRemoved).toEqual(['page1']);
+  expect(comparison.changes.pagesModified).toEqual(['page2']);
+  expect(comparison.changes.componentsAdded).toBe(3);
+  expect(comparison.changes.stylesAdded).toBe(0);
+});
+
+test('Version.compare: 変更がない場合', () => {
+  const version = {
+    ...createMockVersion('v1', '2024-01-01T00:00:00Z'),
+    pagesChanged: ['page1'],
+    componentsChanged: 5,
+    stylesChanged: 3,
+  };
+
+  const comparison = Version.compare(version, version);
+
+  expect(comparison.from).toBe('v1');
+  expect(comparison.to).toBe('v1');
+  expect(comparison.changes.pagesAdded).toEqual([]);
+  expect(comparison.changes.pagesRemoved).toEqual([]);
+  expect(comparison.changes.pagesModified).toEqual(['page1']);
+});
+
+test('Version.isValidVersionId: 有効なバージョンIDを判定', () => {
+  expect(Version.isValidVersionId('123')).toBe(true);
+  expect(Version.isValidVersionId('456789')).toBe(true);
+  expect(Version.isValidVersionId('0')).toBe(true);
+});
+
+test('Version.isValidVersionId: 無効なバージョンIDを判定', () => {
+  expect(Version.isValidVersionId('abc')).toBe(false);
+  expect(Version.isValidVersionId('123abc')).toBe(false);
+  expect(Version.isValidVersionId('v123')).toBe(false);
+  expect(Version.isValidVersionId('')).toBe(false);
+  expect(Version.isValidVersionId('1.2.3')).toBe(false);
+});
+
+test('Version.generateSummary: バージョンの説明を生成', () => {
+  const version = {
+    ...createMockVersion('v1', '2024-01-01T00:00:00Z', 'Release v1.0'),
+    componentsChanged: 10,
+    stylesChanged: 5,
+    pagesChanged: ['page1', 'page2'],
+  };
+
+  const summary = Version.generateSummary(version);
+
+  expect(summary).toContain('Label: Release v1.0');
+  expect(summary).toContain('10 component(s) changed');
+  expect(summary).toContain('5 style(s) changed');
+  expect(summary).toContain('2 page(s) affected');
+});
+
+test('Version.generateSummary: ラベルのみの場合', () => {
+  const version = createMockVersion('v1', '2024-01-01T00:00:00Z', 'Hotfix');
+
+  const summary = Version.generateSummary(version);
+
+  expect(summary).toBe('Label: Hotfix');
+});
+
+test('Version.generateSummary: 変更がない場合', () => {
+  const version = createMockVersion('v1', '2024-01-01T00:00:00Z');
+
+  const summary = Version.generateSummary(version);
+
+  expect(summary).toBe('No significant changes');
+});
+
+test('Version.generateSummary: 複数の変更タイプがある場合', () => {
+  const version = {
+    ...createMockVersion('v1', '2024-01-01T00:00:00Z'),
+    componentsChanged: 1,
+    stylesChanged: 2,
+  };
+
+  const summary = Version.generateSummary(version);
+
+  expect(summary).toContain('1 component(s) changed');
+  expect(summary).toContain('2 style(s) changed');
+  expect(summary).toContain(','); // カンマで区切られている
+});

--- a/src/models/version/index.ts
+++ b/src/models/version/index.ts
@@ -1,0 +1,2 @@
+// Version型とコンパニオンオブジェクトの再エクスポート
+export * from './version.js';

--- a/src/models/version/version.ts
+++ b/src/models/version/version.ts
@@ -1,0 +1,247 @@
+/**
+ * Figmaのバージョン情報を表す型とそのコンパニオンオブジェクト
+ */
+
+import type { FigmaUser } from '../../types/figma-types.js';
+
+/**
+ * Figmaファイルのバージョン情報
+ */
+export interface Version {
+  /** バージョンID */
+  id: string;
+  /** 作成日時（ISO 8601形式） */
+  createdAt: string;
+  /** バージョンラベル */
+  label: string;
+  /** バージョンの説明 */
+  description: string;
+  /** バージョンを作成したユーザー */
+  user: FigmaUser;
+  /** サムネイル画像のURL */
+  thumbnailUrl?: string;
+  /** 変更されたページのID一覧 */
+  pagesChanged?: string[];
+  /** 変更されたコンポーネント数 */
+  componentsChanged?: number;
+  /** 変更されたスタイル数 */
+  stylesChanged?: number;
+}
+
+/**
+ * バージョン比較結果
+ */
+export interface VersionComparison {
+  from: string;
+  to: string;
+  changes: {
+    pagesAdded: string[];
+    pagesRemoved: string[];
+    pagesModified: string[];
+    componentsAdded: number;
+    componentsRemoved: number;
+    componentsModified: number;
+    stylesAdded: number;
+    stylesRemoved: number;
+    stylesModified: number;
+  };
+}
+
+/**
+ * バージョン分析結果
+ */
+export interface VersionAnalysis {
+  totalVersions: number;
+  mostActiveUser: string | null;
+  versionsByUser: Record<string, number>;
+  /** バージョン間の平均時間（ミリ秒） */
+  averageTimeBetweenVersions: number;
+  /** 大きな変更があったバージョン */
+  majorChanges: Version[];
+}
+
+/**
+ * Versionのコンパニオンオブジェクト
+ */
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Version {
+  /**
+   * 指定期間内のバージョンをフィルタリング
+   */
+  export function filterByDateRange(
+    versions: Version[],
+    startDate?: Date,
+    endDate?: Date
+  ): Version[] {
+    return versions.filter((version) => {
+      const versionDate = new Date(version.createdAt);
+      if (startDate && versionDate < startDate) return false;
+      if (endDate && versionDate > endDate) return false;
+      return true;
+    });
+  }
+
+  /**
+   * 特定のユーザーが作成したバージョンをフィルタリング
+   */
+  export function filterByUser(versions: Version[], userId: string): Version[] {
+    return versions.filter((version) => version.user.id === userId);
+  }
+
+  /**
+   * ラベル付きバージョンのみを取得
+   */
+  export function getLabeled(versions: Version[]): Version[] {
+    return versions.filter((version) => version.label && version.label.trim() !== '');
+  }
+
+  /**
+   * 最新のバージョンを取得
+   */
+  export function getLatest(versions: Version[]): Version | null {
+    if (versions.length === 0) return null;
+    
+    return versions.reduce((latest, version) => {
+      const latestDate = new Date(latest.createdAt);
+      const versionDate = new Date(version.createdAt);
+      return versionDate > latestDate ? version : latest;
+    });
+  }
+
+  /**
+   * バージョンを日付順にソート（新しい順）
+   */
+  export function sortByDate(versions: Version[], ascending = false): Version[] {
+    return [...versions].sort((a, b) => {
+      const dateA = new Date(a.createdAt).getTime();
+      const dateB = new Date(b.createdAt).getTime();
+      return ascending ? dateA - dateB : dateB - dateA;
+    });
+  }
+
+  /**
+   * バージョンを分析
+   */
+  export function analyze(versions: Version[]): VersionAnalysis {
+    if (versions.length === 0) {
+      return {
+        totalVersions: 0,
+        mostActiveUser: null,
+        versionsByUser: {},
+        averageTimeBetweenVersions: 0,
+        majorChanges: [],
+      };
+    }
+
+    const versionsByUser: Record<string, number> = {};
+    versions.forEach((version) => {
+      const userId = version.user.id;
+      versionsByUser[userId] = (versionsByUser[userId] || 0) + 1;
+    });
+    const mostActiveUser = Object.entries(versionsByUser).reduce((max, [userId, count]) => {
+      return count > (max[1] || 0) ? [userId, count] : max;
+    }, ['', 0] as [string, number])[0];
+
+    // バージョン間の平均時間を計算
+    let averageTimeBetweenVersions = 0;
+    if (versions.length > 1) {
+      const sortedVersions = sortByDate(versions, true);
+      let totalTime = 0;
+      for (let i = 1; i < sortedVersions.length; i++) {
+        const prevDate = new Date(sortedVersions[i - 1].createdAt);
+        const currDate = new Date(sortedVersions[i].createdAt);
+        totalTime += currDate.getTime() - prevDate.getTime();
+      }
+      averageTimeBetweenVersions = totalTime / (sortedVersions.length - 1);
+    }
+
+    // 大きな変更があったバージョンを特定
+    // 閾値10は暫定値で、実際の使用パターンに基づいて調整が必要
+    // TODO: 閾値を設定可能にすることを検討
+    const majorChanges = versions.filter((version) => {
+      const componentChanges = version.componentsChanged || 0;
+      const styleChanges = version.stylesChanged || 0;
+      return componentChanges >= 10 || styleChanges >= 10;
+    });
+
+    return {
+      totalVersions: versions.length,
+      mostActiveUser,
+      versionsByUser,
+      averageTimeBetweenVersions,
+      majorChanges,
+    };
+  }
+
+  /**
+   * 2つのバージョン間の変更を比較（モック実装）
+   * 
+   * 注意: Figma APIはバージョン間の詳細な差分情報を直接提供しないため、
+   * 実際の比較には各バージョンのファイル全体を取得して差分計算が必要。
+   * 現在は簡易的な比較ロジックのみ実装。
+   * 
+   * @todo 実際のファイル差分計算機能の実装
+   */
+  export function compare(fromVersion: Version, toVersion: Version): VersionComparison {
+    
+    const fromPages = fromVersion.pagesChanged || [];
+    const toPages = toVersion.pagesChanged || [];
+    
+    const pagesAdded = toPages.filter(page => !fromPages.includes(page));
+    const pagesRemoved = fromPages.filter(page => !toPages.includes(page));
+    const pagesModified = toPages.filter(page => fromPages.includes(page));
+    
+    return {
+      from: fromVersion.id,
+      to: toVersion.id,
+      changes: {
+        pagesAdded,
+        pagesRemoved,
+        pagesModified,
+        componentsAdded: Math.max(0, (toVersion.componentsChanged || 0) - (fromVersion.componentsChanged || 0)),
+        componentsRemoved: 0, // APIの制約により削除数は計算不可
+        componentsModified: Math.min(fromVersion.componentsChanged || 0, toVersion.componentsChanged || 0),
+        stylesAdded: Math.max(0, (toVersion.stylesChanged || 0) - (fromVersion.stylesChanged || 0)),
+        stylesRemoved: 0, // APIの制約により削除数は計算不可
+        stylesModified: Math.min(fromVersion.stylesChanged || 0, toVersion.stylesChanged || 0),
+      },
+    };
+  }
+
+  /**
+   * バージョンIDを検証
+   */
+  export function isValidVersionId(versionId: string): boolean {
+    // Figmaのバージョン IDは数値文字列
+    return /^\d+$/.test(versionId);
+  }
+
+  /**
+   * バージョンの説明を生成
+   */
+  export function generateSummary(version: Version): string {
+    const parts: string[] = [];
+    
+    if (version.label) {
+      parts.push(`Label: ${version.label}`);
+    }
+    
+    if (version.componentsChanged && version.componentsChanged > 0) {
+      parts.push(`${version.componentsChanged} component(s) changed`);
+    }
+    
+    if (version.stylesChanged && version.stylesChanged > 0) {
+      parts.push(`${version.stylesChanged} style(s) changed`);
+    }
+    
+    if (version.pagesChanged && version.pagesChanged.length > 0) {
+      parts.push(`${version.pagesChanged.length} page(s) affected`);
+    }
+    
+    if (parts.length === 0) {
+      return 'No significant changes';
+    }
+    
+    return parts.join(', ');
+  }
+}

--- a/src/tools/version/get-versions-args.ts
+++ b/src/tools/version/get-versions-args.ts
@@ -1,14 +1,7 @@
 import { z } from 'zod';
 
-// Zodスキーマ定義
 export const GetVersionsArgsSchema = z.object({
   fileKey: z.string().describe('The Figma file key'),
-  includeDetails: z.boolean().optional().describe('Include detailed version information'),
-  comparePair: z
-    .tuple([z.string(), z.string()])
-    .optional()
-    .describe('Compare two version IDs [from, to]'),
 });
 
-// 型の自動生成（スキーマと同じ名前）
 export type GetVersionsArgs = z.infer<typeof GetVersionsArgsSchema>;

--- a/src/tools/version/index.ts
+++ b/src/tools/version/index.ts
@@ -1,13 +1,31 @@
 import type { FigmaApiClient } from '../../api/figma-api-client.js';
-import { createGetVersionsTool } from './list.js';
-import type { VersionTool } from './types.js';
+import { GetVersionsTool, GetVersionsToolDefinition } from './list.js';
+import type { GetVersionsArgs } from './get-versions-args.js';
+import type { GetVersionsResponse } from '../../types/api/responses/version-responses.js';
 
 interface VersionTools {
-  getVersions: VersionTool;
+  getVersions: {
+    name: typeof GetVersionsToolDefinition.name;
+    description: typeof GetVersionsToolDefinition.description;
+    inputSchema: typeof GetVersionsToolDefinition.inputSchema;
+    execute: (args: GetVersionsArgs) => Promise<GetVersionsResponse>;
+  };
 }
 
 export const createVersionTools = (apiClient: FigmaApiClient): VersionTools => {
+  const tool = GetVersionsTool.from(apiClient);
   return {
-    getVersions: createGetVersionsTool(apiClient),
+    getVersions: {
+      ...GetVersionsToolDefinition,
+      execute: (args: GetVersionsArgs) => GetVersionsTool.execute(tool, args),
+    },
   };
 };
+
+// 再エクスポート
+export {
+  GetVersionsToolDefinition,
+  GetVersionsTool,
+} from './list.js';
+export * from './types.js';
+export * from './get-versions-args.js';

--- a/src/tools/version/list.test.ts
+++ b/src/tools/version/list.test.ts
@@ -1,131 +1,74 @@
-import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import { test, expect, beforeAll, afterAll } from 'vitest';
 import { MockFigmaServer } from '../../__tests__/mocks/server.js';
 import { createFigmaApiClient } from '../../api/figma-api-client.js';
 import type { FigmaApiClient } from '../../api/figma-api-client.js';
 import { TestPorts } from '../../constants/index.js';
 
-describe('get-versions', () => {
-  let mockServer: MockFigmaServer;
-  let apiClient: FigmaApiClient;
+let mockServer: MockFigmaServer;
+let apiClient: FigmaApiClient;
 
-  beforeAll(async () => {
-    // モックサーバーを起動
-    mockServer = new MockFigmaServer(TestPorts.VERSION_TEST);
-    await mockServer.start();
+beforeAll(async () => {
+  mockServer = new MockFigmaServer(TestPorts.VERSION_TEST);
+  await mockServer.start();
+  apiClient = createFigmaApiClient('test-token', `http://localhost:${TestPorts.VERSION_TEST}`);
+});
 
-    // APIクライアントを初期化（baseURLを直接指定）
-    apiClient = createFigmaApiClient('test-token', `http://localhost:${TestPorts.VERSION_TEST}`);
+afterAll(async () => {
+  await mockServer.stop();
+});
+
+test('GetVersionsTool: バージョン履歴を取得できる', async () => {
+  const fileKey = 'test-file-key';
+
+  const { GetVersionsTool } = await import('./list.js');
+  const tool = GetVersionsTool.from(apiClient);
+  const result = await GetVersionsTool.execute(tool, { fileKey });
+
+  expect(result.versions).toHaveLength(2);
+  expect(result.versions[0]).toMatchObject({
+    id: 'version1',
+    createdAt: '2024-01-01T00:00:00Z',
+    label: 'Initial design',
+    description: 'First version of the design',
   });
+});
 
-  afterAll(async () => {
-    await mockServer.stop();
-  });
+test('GetVersionsTool: APIエラーを適切に処理する', async () => {
+  const errorClient = createFigmaApiClient('invalid-token', `http://localhost:${TestPorts.VERSION_TEST}`);
+  const fileKey = 'test-file-key';
 
-  test('バージョン履歴を取得できる', async () => {
-    // Arrange
-    const fileKey = 'test-file-key';
+  const { GetVersionsTool } = await import('./list.js');
+  const tool = GetVersionsTool.from(errorClient);
 
-    // Act
-    const { createVersionTools } = await import('./index.js');
-    const tools = createVersionTools(apiClient);
-    const result = await tools.getVersions.execute({ fileKey });
+  await expect(GetVersionsTool.execute(tool, { fileKey })).rejects.toThrow();
+});
 
-    // Assert
-    // モックサーバーはsnake_caseで返すので、camelCaseに変換される
-    expect(result.versions).toHaveLength(2);
-    expect(result.versions[0]).toMatchObject({
-      id: 'version1',
-      createdAt: '2024-01-01T00:00:00Z',
-      label: 'Initial design',
-      description: 'First version of the design',
-    });
-  });
+test.skip('GetVersionsTool: 空のバージョンリストを処理できる', async () => {
+  // TODO: MockFigmaServerに空のレスポンスを返すオプションを追加してテストを実装
+});
 
-  test('APIエラーを適切に処理する', async () => {
-    // Arrange - 無効なトークンでクライアントを作成
-    const errorClient = createFigmaApiClient('invalid-token', `http://localhost:${TestPorts.VERSION_TEST}`);
-    const fileKey = 'test-file-key';
+test('GetVersionsTool: バージョンが時系列順（新しい順）でソートされている', async () => {
+  const fileKey = 'test-file-key';
 
-    // Act & Assert
-    const { createVersionTools } = await import('./index.js');
-    const tools = createVersionTools(errorClient);
+  const { GetVersionsTool } = await import('./list.js');
+  const tool = GetVersionsTool.from(apiClient);
+  const result = await GetVersionsTool.execute(tool, { fileKey });
 
-    await expect(tools.getVersions.execute({ fileKey })).rejects.toThrow();
-  });
+  expect(result.versions).toHaveLength(2);
+  expect(result.versions[0].id).toBe('version1');
+  expect(result.versions[1].id).toBe('version2');
+});
 
-  test('空のバージョンリストを処理できる', async () => {
-    // Note: MockFigmaServerは常にデータを返すため、このテストケースは
-    // 実際のAPIの振る舞いをシミュレートしていません。
-    // 実際のテストでは、モックサーバーのレスポンスをカスタマイズする必要があります。
-    // このテストはスキップします。
-  });
 
-  test('バージョンが時系列順（新しい順）でソートされている', async () => {
-    // Arrange
-    const fileKey = 'test-file-key';
 
-    // Act
-    const { createVersionTools } = await import('./index.js');
-    const tools = createVersionTools(apiClient);
-    const result = await tools.getVersions.execute({ fileKey });
+test('GetVersionsTool: バージョンのラベルと説明を取得できる', async () => {
+  const fileKey = 'test-file-key';
 
-    // Assert - モックサーバーはversion1, version2の順（古い順）で返す
-    // APIは時系列順のデータを返すが、新しい順か古い順かは実装による
-    expect(result.versions).toHaveLength(2);
-    expect(result.versions[0].id).toBe('version1');
-    expect(result.versions[1].id).toBe('version2');
-  });
+  const { GetVersionsTool } = await import('./list.js');
+  const tool = GetVersionsTool.from(apiClient);
+  const result = await GetVersionsTool.execute(tool, { fileKey });
 
-  test('includeDetailsオプションで詳細情報を取得できる', async () => {
-    // Arrange
-    const fileKey = 'test-file-key';
-
-    // Act
-    const { createVersionTools } = await import('./index.js');
-    const tools = createVersionTools(apiClient);
-    const result = await tools.getVersions.execute({
-      fileKey,
-      includeDetails: true,
-    });
-
-    // Assert - モックサーバーはthumbnailUrlを返す
-    const version = result.versions[0];
-    expect(version.thumbnailUrl).toBeDefined();
-    expect(version.thumbnailUrl).toContain('example.com');
-  });
-
-  test('comparePairオプションで2つのバージョンを比較できる', async () => {
-    // Arrange
-    const fileKey = 'test-file-key';
-
-    // Act
-    const { createVersionTools } = await import('./index.js');
-    const tools = createVersionTools(apiClient);
-    const result = await tools.getVersions.execute({
-      fileKey,
-      comparePair: ['version1', 'version2'],
-    });
-
-    // Assert
-    expect(result.comparison).toBeDefined();
-    expect(result.comparison?.from).toBe('version1');
-    expect(result.comparison?.to).toBe('version2');
-    // モック実装のため、実際の差分は計算されない
-    expect(result.comparison?.changes).toBeDefined();
-  });
-
-  test('バージョンのラベルと説明を取得できる', async () => {
-    // Arrange
-    const fileKey = 'test-file-key';
-
-    // Act
-    const { createVersionTools } = await import('./index.js');
-    const tools = createVersionTools(apiClient);
-    const result = await tools.getVersions.execute({ fileKey });
-
-    // Assert
-    const version = result.versions[0];
-    expect(version.label).toBe('Initial design');
-    expect(version.description).toBe('First version of the design');
-  });
+  const version = result.versions[0];
+  expect(version.label).toBe('Initial design');
+  expect(version.description).toBe('First version of the design');
 });

--- a/src/types/api/responses/version-responses.ts
+++ b/src/types/api/responses/version-responses.ts
@@ -1,22 +1,6 @@
 // バージョン関連のAPIレスポンス型定義
 
-import type { Version } from '../../figma-types.js';
-
-export interface VersionComparison {
-  from: string;
-  to: string;
-  changes: {
-    pagesAdded: string[];
-    pagesRemoved: string[];
-    pagesModified: string[];
-    componentsAdded: number;
-    componentsRemoved: number;
-    componentsModified: number;
-    stylesAdded: number;
-    stylesRemoved: number;
-    stylesModified: number;
-  };
-}
+import type { Version, VersionComparison } from '../../../models/version/index.js';
 
 export interface GetVersionsResponse {
   versions: Version[];

--- a/src/types/figma-types.ts
+++ b/src/types/figma-types.ts
@@ -148,16 +148,3 @@ export interface FigmaUser {
   imgUrl: string;
   email: string;
 }
-
-
-export interface Version {
-  id: string;
-  createdAt: string;
-  label: string;
-  description: string;
-  user: FigmaUser;
-  thumbnailUrl?: string;
-  pagesChanged?: string[];
-  componentsChanged?: number;
-  stylesChanged?: number;
-}


### PR DESCRIPTION
## 概要

versionツールを、styleツールと同じコンパニオンオブジェクトパターンに変更しました。これにより、ツール間の実装パターンが統一され、コードの保守性が向上します。

## 変更内容

### 🎯 変更の種類

- [x] ♻️ リファクタリング (Refactoring)
- [x] 🚨 テスト追加/修正 (Tests)
- [x] 🗑️ 削除 (Removal)

### 📝 詳細な変更内容

#### 追加された機能・修正

- Version型をコンパニオンオブジェクトパターンで実装
  - `models/version/version.ts`に新規作成
  - filterByDateRange、analyze、compareなどのユーティリティメソッドを実装
- GetVersionsToolをコンパニオンオブジェクトパターンに変更
  - `GetVersionsTool.from(apiClient)`でインスタンス生成
  - `GetVersionsTool.execute(tool, args)`で実行
- Version型の包括的なテストスイートを追加

#### 変更されたファイル

- `src/models/version/` - 新規ディレクトリとVersion型の実装
- `src/tools/version/list.ts` - コンパニオンオブジェクトパターンに変更
- `src/tools/version/index.ts` - エクスポート構造の更新
- `src/index.ts` - 新しいツール構造での使用
- `src/types/figma-types.ts` - Version型を削除（modelsに移動）

#### 削除されたファイル・機能

- 不要なモック機能（includeDetails、comparePair）を削除
- GetVersionsToolのanalyzeResponse、filterResponseByDateRangeメソッドを削除（Versionモデル側に移動）
- テストファイルの過剰なコメントを削除
- 自明な実装コメントを削除

## 🧪 テスト

### テスト実行方法

```bash
npm test -- src/tools/version/
npm test -- src/models/version/
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 手動テスト (Manual testing)

### テスト結果

すべてのテストが成功しています：
- versionツール: 4 passed, 1 skipped
- Versionモデル: 包括的なテストスイート実装済み

## 🔍 レビューポイント

- コンパニオンオブジェクトパターンの実装がstyleツールと一貫性があるか
- Version型のユーティリティメソッドの実装が適切か
- 不要なコードが適切に削除されているか
- コメントの改善が適切か（JSDocの充実、不要なコメントの削除）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] セルフレビューを実施した

## 🤝 レビュアーへのお願い

- styleツールと同じパターンになっているか確認をお願いします
- Version型のメソッドが適切に実装されているか確認をお願いします