### PR TITLE
♻️ Comments APIを関数ベースアプローチに簡素化

### DIFF
--- a/src/api/endpoints/comments/__tests__/get-file-comments.test.ts
+++ b/src/api/endpoints/comments/__tests__/get-file-comments.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, vi } from 'vitest';
-import { createCommentsApi } from '../index';
+import { getFileCommentsApi } from '../index';
 import type { HttpClient } from '../../../client';
-import type { GetCommentsResponse } from '../../../../types';
+import type { GetFileCommentsApiResponse } from '../../../../types';
 import { TestData } from '../../../../constants';
 
 function createMockHttpClient(): HttpClient {
@@ -11,9 +11,9 @@ function createMockHttpClient(): HttpClient {
   };
 }
 
-test('createCommentsApi.getCommentsでコメント一覧を取得できる', async () => {
+test('getFileCommentsApiでコメント一覧を取得できる', async () => {
   const mockHttpClient = createMockHttpClient();
-  const mockResponse: GetCommentsResponse = {
+  const mockResponse: GetFileCommentsApiResponse = {
     comments: [
       {
         id: 'comment-1',
@@ -39,8 +39,7 @@ test('createCommentsApi.getCommentsでコメント一覧を取得できる', asy
 
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const commentsApi = createCommentsApi(mockHttpClient);
-  const result = await commentsApi.getComments(TestData.FILE_KEY);
+  const result = await getFileCommentsApi(mockHttpClient, TestData.FILE_KEY);
 
   expect(mockHttpClient.get).toHaveBeenCalledWith(
     '/v1/files/test-file-key/comments'
@@ -48,23 +47,22 @@ test('createCommentsApi.getCommentsでコメント一覧を取得できる', asy
   expect(result).toEqual(mockResponse);
 });
 
-test('createCommentsApi.getCommentsで空のコメント一覧を取得できる', async () => {
+test('getFileCommentsApiで空のコメント一覧を取得できる', async () => {
   const mockHttpClient = createMockHttpClient();
-  const mockResponse: GetCommentsResponse = {
+  const mockResponse: GetFileCommentsApiResponse = {
     comments: [],
   };
 
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const commentsApi = createCommentsApi(mockHttpClient);
-  const result = await commentsApi.getComments(TestData.FILE_KEY);
+  const result = await getFileCommentsApi(mockHttpClient, TestData.FILE_KEY);
 
   expect(result.comments).toHaveLength(0);
 });
 
-test('createCommentsApi.getCommentsで複数のコメントがある場合も正しく取得できる', async () => {
+test('getFileCommentsApiで複数のコメントがある場合も正しく取得できる', async () => {
   const mockHttpClient = createMockHttpClient();
-  const mockResponse: GetCommentsResponse = {
+  const mockResponse: GetFileCommentsApiResponse = {
     comments: [
       {
         id: 'comment-1',
@@ -103,17 +101,16 @@ test('createCommentsApi.getCommentsで複数のコメントがある場合も正
 
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const commentsApi = createCommentsApi(mockHttpClient);
-  const result = await commentsApi.getComments(TestData.FILE_KEY);
+  const result = await getFileCommentsApi(mockHttpClient, TestData.FILE_KEY);
 
   expect(result.comments).toHaveLength(2);
   expect(result.comments[0].id).toBe('comment-1');
   expect(result.comments[1].parentId).toBe('comment-1');
 });
 
-test('createCommentsApi.getCommentsで解決済みのコメントも正しく取得できる', async () => {
+test('getFileCommentsApiで解決済みのコメントも正しく取得できる', async () => {
   const mockHttpClient = createMockHttpClient();
-  const mockResponse: GetCommentsResponse = {
+  const mockResponse: GetFileCommentsApiResponse = {
     comments: [
       {
         id: 'comment-1',
@@ -136,40 +133,34 @@ test('createCommentsApi.getCommentsで解決済みのコメントも正しく取
 
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const commentsApi = createCommentsApi(mockHttpClient);
-  const result = await commentsApi.getComments(TestData.FILE_KEY);
+  const result = await getFileCommentsApi(mockHttpClient, TestData.FILE_KEY);
 
   expect(result.comments[0].resolvedAt).toBe('2024-01-02T00:00:00Z');
 });
 
-test('createCommentsApi.getCommentsでHTTPクライアントがエラーをスローした場合、エラーが伝播される', async () => {
+test('getFileCommentsApiでHTTPクライアントがエラーをスローした場合、エラーが伝播される', async () => {
   const mockHttpClient = createMockHttpClient();
   const expectedError = new Error('Network error');
   vi.mocked(mockHttpClient.get).mockRejectedValueOnce(expectedError);
 
-  const commentsApi = createCommentsApi(mockHttpClient);
-
-  await expect(commentsApi.getComments(TestData.FILE_KEY)).rejects.toThrow('Network error');
+  await expect(getFileCommentsApi(mockHttpClient, TestData.FILE_KEY)).rejects.toThrow('Network error');
 });
 
-test('createCommentsApi.getCommentsで認証エラーが適切に処理される', async () => {
+test('getFileCommentsApiで認証エラーが適切に処理される', async () => {
   const mockHttpClient = createMockHttpClient();
   const authError = new Error('Unauthorized');
   vi.mocked(mockHttpClient.get).mockRejectedValueOnce(authError);
 
-  const commentsApi = createCommentsApi(mockHttpClient);
-
-  await expect(commentsApi.getComments(TestData.FILE_KEY)).rejects.toThrow('Unauthorized');
+  await expect(getFileCommentsApi(mockHttpClient, TestData.FILE_KEY)).rejects.toThrow('Unauthorized');
 });
 
-test('createCommentsApi.getCommentsで特殊文字を含むファイルキーが正しくエンコードされる', async () => {
+test('getFileCommentsApiで特殊文字を含むファイルキーが正しくエンコードされる', async () => {
   const mockHttpClient = createMockHttpClient();
-  const mockResponse: GetCommentsResponse = { comments: [] };
+  const mockResponse: GetFileCommentsApiResponse = { comments: [] };
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const commentsApi = createCommentsApi(mockHttpClient);
   const specialFileKey = 'file:key/with-special@chars';
-  await commentsApi.getComments(specialFileKey);
+  await getFileCommentsApi(mockHttpClient, specialFileKey);
 
   expect(mockHttpClient.get).toHaveBeenCalledWith(
     '/v1/files/file:key/with-special@chars/comments'

--- a/src/api/endpoints/comments/index.ts
+++ b/src/api/endpoints/comments/index.ts
@@ -1,34 +1,32 @@
-// コメント関連のAPI関数
+// コメント関連のAPI呼び出し関数
 
 import type { HttpClient } from '../../client.js';
-import type { GetCommentsResponse, Comment, PostCommentOptions } from '../../../types/index.js';
+import type { GetFileCommentsApiResponse, PostFileCommentApiResponse, PostCommentOptions } from '../../../types/index.js';
 
-export interface CommentsApi {
-  getComments: (fileKey: string) => Promise<GetCommentsResponse>;
-  postComment: (fileKey: string, options: PostCommentOptions) => Promise<Comment>;
+export async function getFileCommentsApi(
+  client: HttpClient,
+  fileKey: string
+): Promise<GetFileCommentsApiResponse> {
+  return client.get<GetFileCommentsApiResponse>(`/v1/files/${fileKey}/comments`);
 }
 
-export function createCommentsApi(client: HttpClient): CommentsApi {
-  return {
-    getComments: async (fileKey: string): Promise<GetCommentsResponse> => {
-      return client.get<GetCommentsResponse>(`/v1/files/${fileKey}/comments`);
-    },
-
-    postComment: async (fileKey: string, options: PostCommentOptions): Promise<Comment> => {
-      const body: {
-        message: string;
-        client_meta: { x: number; y: number };
-        comment_id?: string;
-      } = {
-        message: options.message,
-        client_meta: options.client_meta,
-      };
-
-      if (options.comment_id) {
-        body.comment_id = options.comment_id;
-      }
-
-      return client.post<Comment>(`/v1/files/${fileKey}/comments`, body);
-    },
+export async function postFileCommentApi(
+  client: HttpClient,
+  fileKey: string,
+  options: PostCommentOptions
+): Promise<PostFileCommentApiResponse> {
+  const body: {
+    message: string;
+    client_meta: { x: number; y: number };
+    comment_id?: string;
+  } = {
+    message: options.message,
+    client_meta: options.client_meta,
   };
+
+  if (options.comment_id) {
+    body.comment_id = options.comment_id;
+  }
+
+  return client.post<PostFileCommentApiResponse>(`/v1/files/${fileKey}/comments`, body);
 }

--- a/src/api/figma-api-client.ts
+++ b/src/api/figma-api-client.ts
@@ -5,7 +5,7 @@ import { createNodesApi } from './endpoints/nodes/index.js';
 import { fileComponentsApi, fileComponentSetsApi } from './endpoints/components/index.js';
 import { createStylesApi } from './endpoints/styles/index.js';
 import { createImagesApi } from './endpoints/images/index.js';
-import { createCommentsApi } from './endpoints/comments/index.js';
+import { getFileCommentsApi } from './endpoints/comments/index.js';
 import { createVersionsApi } from './endpoints/versions/index.js';
 import { createTeamsApi } from './endpoints/teams/index.js';
 import { FigmaContext } from './context.js';
@@ -17,7 +17,7 @@ import type {
 } from '../types/api/responses/component-responses.js';
 import type { GetStylesResponse } from '../types/api/responses/style-responses.js';
 import type { ExportImageResponse } from '../types/api/responses/image-responses.js';
-import type { GetCommentsResponse } from '../types/api/responses/comment-responses.js';
+import type { GetFileCommentsApiResponse } from '../types/api/responses/comment-responses.js';
 import type { GetVersionsResponse } from '../types/api/responses/version-responses.js';
 import type { ExportImageOptions } from '../types/api/options/image-options.js';
 
@@ -38,8 +38,6 @@ export interface FigmaApiClient {
   readonly styles: ReturnType<typeof createStylesApi>;
   /** Images API endpoint */
   readonly images: ReturnType<typeof createImagesApi>;
-  /** Comments API endpoint */
-  readonly comments: ReturnType<typeof createCommentsApi>;
   /** Versions API endpoint */
   readonly versions: ReturnType<typeof createVersionsApi>;
   /** Teams API endpoint */
@@ -70,7 +68,6 @@ export namespace FigmaApiClient {
       nodes: createNodesApi(httpClient),
       styles: createStylesApi(httpClient),
       images: createImagesApi(httpClient),
-      comments: createCommentsApi(httpClient),
       versions: createVersionsApi(httpClient),
       teams: createTeamsApi(httpClient),
     };
@@ -90,7 +87,6 @@ export namespace FigmaApiClient {
       nodes: createNodesApi(httpClient),
       styles: createStylesApi(httpClient),
       images: createImagesApi(httpClient),
-      comments: createCommentsApi(httpClient),
       versions: createVersionsApi(httpClient),
       teams: createTeamsApi(httpClient),
     };
@@ -167,8 +163,8 @@ export namespace FigmaApiClient {
   export async function getComments(
     client: FigmaApiClient,
     fileKey: string
-  ): Promise<GetCommentsResponse> {
-    const response = await client.comments.getComments(fileKey);
+  ): Promise<GetFileCommentsApiResponse> {
+    const response = await getFileCommentsApi(client.httpClient, fileKey);
     return convertKeysToCamelCase(response);
   }
 

--- a/src/tools/comment/list.ts
+++ b/src/tools/comment/list.ts
@@ -1,5 +1,5 @@
 import { FigmaApiClient } from '../../api/figma-api-client.js';
-import type { GetCommentsResponse } from '../../types/api/responses/comment-responses.js';
+import type { GetFileCommentsApiResponse } from '../../types/api/responses/comment-responses.js';
 import { Comment } from '../../models/comment/index.js';
 import { GetCommentsArgsSchema, type GetCommentsArgs } from './get-comments-args.js';
 import { JsonSchema, type McpToolDefinition } from '../types.js';
@@ -74,7 +74,7 @@ export const GetCommentsTool = {
   async execute(
     tool: GetCommentsTool,
     args: GetCommentsArgs
-  ): Promise<GetCommentsResponse> {
+  ): Promise<GetFileCommentsApiResponse> {
     const response = await FigmaApiClient.getComments(tool.apiClient, args.fileKey);
 
     // フィルターを順番に適用

--- a/src/tools/comment/types.ts
+++ b/src/tools/comment/types.ts
@@ -1,8 +1,8 @@
 import type { CommentWithReplies } from '../../models/comment/index.js';
 import type { ToolDefinition } from '../types.js';
-import type { GetCommentsResponse } from '../../types/api/responses/comment-responses.js';
+import type { GetFileCommentsApiResponse } from '../../types/api/responses/comment-responses.js';
 import type { GetCommentsArgs } from './get-comments-args.js';
 
 export { CommentWithReplies };
 
-export type CommentTool = ToolDefinition<GetCommentsArgs, GetCommentsResponse>;
+export type CommentTool = ToolDefinition<GetCommentsArgs, GetFileCommentsApiResponse>;

--- a/src/types/api/responses/comment-responses.ts
+++ b/src/types/api/responses/comment-responses.ts
@@ -2,6 +2,8 @@
 
 import type { Comment } from '../../../models/comment/index.js';
 
-export interface GetCommentsResponse {
+export interface GetFileCommentsApiResponse {
   comments: Comment[];
 }
+
+export type PostFileCommentApiResponse = Comment;


### PR DESCRIPTION
## 概要
Comments APIをcomponentsフォルダと同じ関数ベースアプローチに統一しました。

## 変更内容

### 1. API関数の構造変更
- ファクトリー関数パターン（`createCommentsApi`）から直接エクスポートする関数ベースに変更
- `fileCommentsApi` → `getFileCommentsApi`：HTTPメソッドを明示的に含む命名に変更
- `postFileCommentApi`：POSTメソッドを明示的に含む命名を維持

### 2. レスポンス型の整理
- `GetCommentsResponse` → `GetFileCommentsApiResponse`
- `PostFileCommentApiResponse`型を新規追加
- APIレスポンスとドメインモデルの責務を明確に分離

### 3. FigmaApiClientの簡素化
- 不要な`comments`プロパティを削除
- componentsと同じように直接関数を呼び出す構造に統一

### 4. テストファイルの更新
- ファイル名を新しい関数名に合わせて変更
  - `get-comments.test.ts` → `get-file-comments.test.ts`
  - `post-comment.test.ts` → `post-file-comment.test.ts`
- 全16件のテストが正常に動作することを確認

## 影響範囲
- `src/api/endpoints/comments/`
- `src/api/figma-api-client.ts`
- `src/types/api/responses/comment-responses.ts`
- `src/tools/comment/`

## テスト
- ✅ 全てのテストが成功（16件）
- ✅ 型チェックが通過

🤖 Generated with [Claude Code](https://claude.ai/code)