### PR TITLE
♻️ Images APIを関数ベースに変更

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,36 +10,33 @@
         "esbenp.prettier-vscode",
         "GitHub.copilot",
         "GitHub.copilot-chat",
-        "eamodio.gitlens"
+        "eamodio.gitlens",
       ],
       "settings": {
         "terminal.integrated.defaultProfile.linux": "bash",
         "editor.formatOnSave": true,
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
-      }
-    }
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+      },
+    },
   },
   "forwardPorts": [8765],
   "portsAttributes": {
     "8765": {
       "label": "MCP Server",
-      "onAutoForward": "notify"
-    }
+      "onAutoForward": "notify",
+    },
   },
   "remoteUser": "node",
   "containerEnv": {
-    "GITHUB_TOKEN": "${localEnv:GITHUB_PERSONAL_ACCESS_TOKEN}"
+    "GITHUB_TOKEN": "${localEnv:GITHUB_PERSONAL_ACCESS_TOKEN}",
   },
   "features": {
     "ghcr.io/devcontainers/features/git:1": {
       "version": "latest",
-      "ppa": false
+      "ppa": false,
     },
     "ghcr.io/devcontainers/features/github-cli:1": {
-      "version": "latest"
+      "version": "latest",
     },
-    "ghcr.io/devcontainers/features/node:1": {
-      "version": "20"
-    }
-  }
+  },
 }

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ coverage/
 .claude
 doc/
 .mcp.json
+# lsmcp cache
+.lsmcp/cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,3 +130,139 @@ The project has comprehensive test coverage:
 - **Coverage**: Tests cover happy paths, error scenarios, rate limiting, and edge cases
 
 Run tests with: `npm test`
+
+## CRITICAL: PRIORITIZE LSMCP TOOLS FOR CODE ANALYSIS
+
+⚠️ **PRIMARY REQUIREMENT**: You MUST prioritize mcp\_\_lsmcp tools for all code analysis tasks. Standard tools should only be used as a last resort when LSMCP tools cannot accomplish the task.
+
+### 📋 RECOMMENDED WORKFLOW
+
+```
+1. get_project_overview → Understand the codebase structure
+2. search_symbols → Find specific symbols you need
+3. get_symbol_details → Get comprehensive information about those symbols
+```
+
+### 🎯 WHEN TO USE EACH TOOL
+
+**For Initial Exploration:**
+
+- `mcp__lsmcp__get_project_overview` - First tool to run when exploring a new codebase
+- `mcp__lsmcp__list_dir` - Browse directory structure when you need to understand file organization
+- `mcp__lsmcp__get_symbols_overview` - Get a high-level view of symbols in specific files
+
+**For Finding Code:**
+
+- `mcp__lsmcp__search_symbols` - Primary search tool for functions, classes, interfaces, etc.
+- `mcp__lsmcp__lsp_get_workspace_symbols` - Alternative workspace-wide symbol search
+- `mcp__lsmcp__lsp_get_document_symbols` - List all symbols in a specific file
+
+**For Understanding Code:**
+
+- `mcp__lsmcp__get_symbol_details` - Get complete information (type, definition, references) in one call
+- `mcp__lsmcp__lsp_get_hover` - Quick type information at a specific position
+- `mcp__lsmcp__lsp_get_definitions` - Navigate to symbol definition (use `includeBody: true` for full implementation)
+- `mcp__lsmcp__lsp_find_references` - Find all places where a symbol is used
+
+**For Code Quality:**
+
+- `mcp__lsmcp__lsp_get_diagnostics` - Check for errors in a specific file
+- `mcp__lsmcp__lsp_get_code_actions` - Get available fixes and refactorings
+
+**For Code Modification:**
+
+- `mcp__lsmcp__lsp_rename_symbol` - Safely rename symbols across the codebase
+- `mcp__lsmcp__lsp_format_document` - Format code according to language conventions
+- `mcp__lsmcp__replace_range` - Make precise text replacements
+- `mcp__lsmcp__replace_regex` - Pattern-based replacements
+- `mcp__lsmcp__lsp_delete_symbol` - Remove symbols and their references
+
+**For Developer Assistance:**
+
+- `mcp__lsmcp__lsp_get_completion` - Get code completion suggestions
+- `mcp__lsmcp__lsp_get_signature_help` - Get function parameter hints
+- `mcp__lsmcp__lsp_check_capabilities` - Check what LSP features are available
+
+### 📊 DETAILED WORKFLOW EXAMPLES
+
+**1. EXPLORING A NEW CODEBASE**
+
+```
+1. mcp__lsmcp__get_project_overview
+   → Understand structure, main components, statistics
+2. mcp__lsmcp__search_symbols --kind "class"
+   → Find all classes in the project
+3. mcp__lsmcp__get_symbol_details --symbol "MainClass"
+   → Deep dive into specific class implementation
+```
+
+**2. INVESTIGATING A BUG**
+
+```
+1. mcp__lsmcp__search_symbols --name "problematicFunction"
+   → Locate the function
+2. mcp__lsmcp__get_symbol_details --symbol "problematicFunction"
+   → Understand its type, implementation, and usage
+3. mcp__lsmcp__lsp_find_references --symbolName "problematicFunction"
+   → See all places it's called
+4. mcp__lsmcp__lsp_get_diagnostics --relativePath "path/to/file.ts"
+   → Check for errors
+```
+
+**3. REFACTORING CODE**
+
+```
+1. mcp__lsmcp__search_symbols --name "oldMethodName"
+   → Find the method to refactor
+2. mcp__lsmcp__get_symbol_details --symbol "oldMethodName"
+   → Understand current implementation and usage
+3. mcp__lsmcp__lsp_rename_symbol --symbolName "oldMethodName" --newName "newMethodName"
+   → Safely rename across codebase
+4. mcp__lsmcp__lsp_format_document --relativePath "path/to/file.ts"
+   → Clean up formatting
+```
+
+**4. ADDING NEW FEATURES**
+
+```
+1. mcp__lsmcp__get_project_overview
+   → Understand existing architecture
+2. mcp__lsmcp__search_symbols --kind "interface"
+   → Find relevant interfaces to implement
+3. mcp__lsmcp__get_symbol_details --symbol "IUserService"
+   → Understand interface requirements
+4. mcp__lsmcp__lsp_get_completion --line 50
+   → Get suggestions while writing new code
+```
+
+**FALLBACK TOOLS (USE ONLY WHEN NECESSARY):**
+
+- ⚠️ `Read` - Only when you need to see non-code files or LSMCP tools fail
+- ⚠️ `Grep` - For text pattern searches in files (replaces removed search_for_pattern tool)
+- ⚠️ `Glob` - Only when LSMCP file finding doesn't work
+- ⚠️ `LS` - Only for basic directory listing when LSMCP fails
+- ⚠️ `Bash` commands - Only for non-code operations or troubleshooting
+
+### WHEN TO USE FALLBACK TOOLS
+
+Use standard tools ONLY in these situations:
+
+1. **Non-code files**: README, documentation, configuration files
+2. **LSMCP tool failures**: When LSMCP tools return errors or no results
+3. **Debugging**: When troubleshooting why LSMCP tools aren't working
+4. **Special file formats**: Files that LSMCP doesn't support
+5. **Quick verification**: Double-checking LSMCP results when needed
+
+## Memory System
+
+You have access to project memories stored in `.lsmcp/memories/`. Use these tools:
+
+- `mcp__lsmcp__list_memories` - List available memory files
+- `mcp__lsmcp__read_memory` - Read specific memory content
+- `mcp__lsmcp__write_memory` - Create or update memories
+- `mcp__lsmcp__delete_memory` - Delete a memory file
+
+Memories contain important project context, conventions, and guidelines that help maintain consistency.
+
+The context and modes of operation are described below. From them you can infer how to interact with your user
+and which tasks and kinds of interactions are expected of you.

--- a/src/api/data/image/__tests__/fetch-batch.test.ts
+++ b/src/api/data/image/__tests__/fetch-batch.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { ImageExport } from '../image.js';
 import type { FigmaContext } from '../../../context.js';
-import type { ExportImageResponse } from '../../../../types/api/responses/image-responses.js';
+import type { ImageApiResponse } from '../../../../types/api/responses/image-responses.js';
 
 describe('ImageExport.fetchBatch', () => {
   const mockContext: FigmaContext = {
@@ -17,19 +17,20 @@ describe('ImageExport.fetchBatch', () => {
   });
 
   it('複数のバッチを並列で取得できる', async () => {
-    const mockResponse1: ExportImageResponse = {
+    const mockResponse1: ImageApiResponse = {
       images: {
         '1:1': 'https://s3.amazonaws.com/figma/batch1.png',
       },
     };
 
-    const mockResponse2: ExportImageResponse = {
+    const mockResponse2: ImageApiResponse = {
       images: {
         '2:2': 'https://s3.amazonaws.com/figma/batch2.png',
       },
     };
 
-    global.fetch = vi.fn()
+    global.fetch = vi
+      .fn()
       .mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(mockResponse1),
@@ -39,14 +40,10 @@ describe('ImageExport.fetchBatch', () => {
         json: () => Promise.resolve(mockResponse2),
       } as Response);
 
-    const results = await ImageExport.fetchBatch(
-      mockContext,
-      'test-file-key',
-      [
-        { nodeIds: ['1:1'], format: 'PNG' },
-        { nodeIds: ['2:2'], format: 'JPG' },
-      ]
-    );
+    const results = await ImageExport.fetchBatch(mockContext, 'test-file-key', [
+      { nodeIds: ['1:1'], format: 'PNG' },
+      { nodeIds: ['2:2'], format: 'JPG' },
+    ]);
 
     expect(results).toHaveLength(2);
     expect(results[0].urls['1:1']).toBe('https://s3.amazonaws.com/figma/batch1.png');
@@ -65,7 +62,7 @@ describe('ImageExport.fetchBatch', () => {
   });
 
   it('単一のオプションも処理できる', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       images: {
         '3:3': 'https://s3.amazonaws.com/figma/single.png',
       },
@@ -76,11 +73,9 @@ describe('ImageExport.fetchBatch', () => {
       json: () => Promise.resolve(mockResponse),
     } as Response);
 
-    const results = await ImageExport.fetchBatch(
-      mockContext,
-      'test-file-key',
-      [{ nodeIds: ['3:3'], format: 'PNG' }]
-    );
+    const results = await ImageExport.fetchBatch(mockContext, 'test-file-key', [
+      { nodeIds: ['3:3'], format: 'PNG' },
+    ]);
 
     expect(results).toHaveLength(1);
     expect(results[0].urls['3:3']).toBe('https://s3.amazonaws.com/figma/single.png');

--- a/src/api/data/image/__tests__/fetch.test.ts
+++ b/src/api/data/image/__tests__/fetch.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { ImageExport } from '../image.js';
 import type { FigmaContext } from '../../../context.js';
-import type { ExportImageResponse } from '../../../../types/api/responses/image-responses.js';
+import type { ImageApiResponse } from '../../../../types/api/responses/image-responses.js';
 
 describe('ImageExport.fetch', () => {
   const mockContext: FigmaContext = {
@@ -17,7 +17,7 @@ describe('ImageExport.fetch', () => {
   });
 
   it('画像エクスポートURLを取得できる', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       images: {
         '1:1': 'https://s3.amazonaws.com/figma/image1.png',
         '2:2': 'https://s3.amazonaws.com/figma/image2.png',
@@ -29,11 +29,11 @@ describe('ImageExport.fetch', () => {
       json: () => Promise.resolve(mockResponse),
     } as Response);
 
-    const imageExport = await ImageExport.fetch(
-      mockContext,
-      'test-file-key',
-      { nodeIds: ['1:1', '2:2'], format: 'PNG', scale: 2 }
-    );
+    const imageExport = await ImageExport.fetch(mockContext, 'test-file-key', {
+      nodeIds: ['1:1', '2:2'],
+      format: 'PNG',
+      scale: 2,
+    });
 
     expect(imageExport.urls['1:1']).toBe('https://s3.amazonaws.com/figma/image1.png');
     expect(imageExport.urls['2:2']).toBe('https://s3.amazonaws.com/figma/image2.png');
@@ -50,7 +50,7 @@ describe('ImageExport.fetch', () => {
   });
 
   it('SVGフォーマットを指定できる', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       images: {
         '3:3': 'https://s3.amazonaws.com/figma/image.svg',
       },
@@ -61,11 +61,7 @@ describe('ImageExport.fetch', () => {
       json: () => Promise.resolve(mockResponse),
     } as Response);
 
-    await ImageExport.fetch(
-      mockContext,
-      'test-file-key',
-      { nodeIds: ['3:3'], format: 'SVG' }
-    );
+    await ImageExport.fetch(mockContext, 'test-file-key', { nodeIds: ['3:3'], format: 'SVG' });
 
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringContaining('format=SVG'),
@@ -74,7 +70,7 @@ describe('ImageExport.fetch', () => {
   });
 
   it('PDFフォーマットを指定できる', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       images: {
         '4:4': 'https://s3.amazonaws.com/figma/document.pdf',
       },
@@ -85,11 +81,7 @@ describe('ImageExport.fetch', () => {
       json: () => Promise.resolve(mockResponse),
     } as Response);
 
-    await ImageExport.fetch(
-      mockContext,
-      'test-file-key',
-      { nodeIds: ['4:4'], format: 'PDF' }
-    );
+    await ImageExport.fetch(mockContext, 'test-file-key', { nodeIds: ['4:4'], format: 'PDF' });
 
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringContaining('format=PDF'),
@@ -98,7 +90,7 @@ describe('ImageExport.fetch', () => {
   });
 
   it('スケールを指定できる', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       images: {
         '5:5': 'https://s3.amazonaws.com/figma/image@3x.png',
       },
@@ -109,11 +101,7 @@ describe('ImageExport.fetch', () => {
       json: () => Promise.resolve(mockResponse),
     } as Response);
 
-    await ImageExport.fetch(
-      mockContext,
-      'test-file-key',
-      { nodeIds: ['5:5'], scale: 3 }
-    );
+    await ImageExport.fetch(mockContext, 'test-file-key', { nodeIds: ['5:5'], scale: 3 });
 
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringContaining('scale=3'),
@@ -134,7 +122,7 @@ describe('ImageExport.fetch', () => {
   });
 
   it('空のレスポンスでも正常に処理できる', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       images: {},
     };
 
@@ -144,7 +132,7 @@ describe('ImageExport.fetch', () => {
     } as Response);
 
     const result = await ImageExport.fetch(mockContext, 'test-file-key', { nodeIds: ['invalid'] });
-    
+
     expect(result.urls).toEqual({});
     expect(result.nodeIds).toEqual(['invalid']);
   });

--- a/src/api/data/image/image.ts
+++ b/src/api/data/image/image.ts
@@ -1,5 +1,5 @@
 import type { FigmaContext } from '../../context.js';
-import type { ExportImageResponse } from '../../../types/api/responses/image-responses.js';
+import type { ImageApiResponse } from '../../../types/api/responses/image-responses.js';
 
 /**
  * 画像エクスポートのフォーマット
@@ -66,7 +66,7 @@ export namespace ImageExport {
     }
 
     const url = `${context.baseUrl}/v1/images/${fileKey}?${params.toString()}`;
-    
+
     const response = await globalThis.fetch(url, {
       method: 'GET',
       headers: context.headers,
@@ -76,7 +76,7 @@ export namespace ImageExport {
       throw new Error(`Failed to fetch images: ${response.status} ${response.statusText}`);
     }
 
-    const data = await response.json() as ExportImageResponse;
+    const data = (await response.json()) as ImageApiResponse;
 
     return {
       nodeIds: options.nodeIds,
@@ -98,9 +98,7 @@ export namespace ImageExport {
       return [];
     }
 
-    const promises = optionsList.map(options =>
-      fetch(context, fileKey, options)
-    );
+    const promises = optionsList.map((options) => fetch(context, fileKey, options));
 
     return await Promise.all(promises);
   }

--- a/src/api/endpoints/images/__tests__/images-api.test.ts
+++ b/src/api/endpoints/images/__tests__/images-api.test.ts
@@ -1,12 +1,12 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { createImagesApi } from '../index';
+import { imagesApi } from '../index';
 import type { HttpClient } from '../../../client';
-import type { ExportImageResponse } from '../../../../types';
+import type { ImageApiResponse } from '../../../../types';
 import type { DeepSnakeCase } from '../../../../utils/type-transformers';
 import type { ExportImageOptions } from '../../../../types/api/options/image-options';
 import { TestData } from '../../../../constants';
 
-describe('createImagesApi - exportImages', () => {
+describe('imagesApi', () => {
   let mockHttpClient: HttpClient;
 
   beforeEach(() => {
@@ -18,7 +18,7 @@ describe('createImagesApi - exportImages', () => {
   });
 
   test('画像をエクスポートできる', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       err: undefined,
       images: {
         '1:1': 'https://example.com/image1.png',
@@ -28,25 +28,24 @@ describe('createImagesApi - exportImages', () => {
 
     vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-    const imagesApi = createImagesApi(mockHttpClient);
     const options: DeepSnakeCase<ExportImageOptions> = {
       ids: ['1:1', '2:2'],
     };
 
-    const result = await imagesApi.exportImages(TestData.FILE_KEY, options);
+    const result = await imagesApi(mockHttpClient, TestData.FILE_KEY, options);
 
     expect(mockHttpClient.get).toHaveBeenCalledWith(
       '/v1/images/test-file-key',
       expect.any(URLSearchParams)
     );
-    
+
     const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
     expect(calledParams?.toString()).toContain('ids=1%3A1%2C2%3A2');
     expect(result).toEqual(mockResponse);
   });
 
   test('単一の画像をエクスポートできる', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       err: undefined,
       images: {
         '1:1': 'https://example.com/image.png',
@@ -55,65 +54,61 @@ describe('createImagesApi - exportImages', () => {
 
     vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-    const imagesApi = createImagesApi(mockHttpClient);
     const options: DeepSnakeCase<ExportImageOptions> = {
       ids: ['1:1'],
     };
 
-    const result = await imagesApi.exportImages(TestData.FILE_KEY, options);
+    const result = await imagesApi(mockHttpClient, TestData.FILE_KEY, options);
 
     expect(result.images).toHaveProperty('1:1');
   });
 
   test('スケールオプションを指定してエクスポートできる', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       err: undefined,
       images: { '1:1': 'https://example.com/image.png' },
     };
 
     vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-    const imagesApi = createImagesApi(mockHttpClient);
     const options: DeepSnakeCase<ExportImageOptions> = {
       ids: ['1:1'],
       scale: 2,
     };
 
-    await imagesApi.exportImages(TestData.FILE_KEY, options);
+    await imagesApi(mockHttpClient, TestData.FILE_KEY, options);
 
     const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
     expect(calledParams?.toString()).toContain('scale=2');
   });
 
   test('フォーマットオプションを指定してエクスポートできる', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       err: undefined,
       images: { '1:1': 'https://example.com/image.svg' },
     };
 
     vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-    const imagesApi = createImagesApi(mockHttpClient);
     const options: DeepSnakeCase<ExportImageOptions> = {
       ids: ['1:1'],
       format: 'svg',
     };
 
-    await imagesApi.exportImages(TestData.FILE_KEY, options);
+    await imagesApi(mockHttpClient, TestData.FILE_KEY, options);
 
     const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
     expect(calledParams?.toString()).toContain('format=svg');
   });
 
   test('SVGオプションを指定してエクスポートできる', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       err: undefined,
       images: { '1:1': 'https://example.com/image.svg' },
     };
 
     vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-    const imagesApi = createImagesApi(mockHttpClient);
     const options: DeepSnakeCase<ExportImageOptions> = {
       ids: ['1:1'],
       format: 'svg',
@@ -121,7 +116,7 @@ describe('createImagesApi - exportImages', () => {
       svg_simplify_stroke: false,
     };
 
-    await imagesApi.exportImages(TestData.FILE_KEY, options);
+    await imagesApi(mockHttpClient, TestData.FILE_KEY, options);
 
     const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
     expect(calledParams?.toString()).toContain('svg_include_id=true');
@@ -129,54 +124,51 @@ describe('createImagesApi - exportImages', () => {
   });
 
   test('use_absolute_boundsオプションを指定してエクスポートできる', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       err: undefined,
       images: { '1:1': 'https://example.com/image.png' },
     };
 
     vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-    const imagesApi = createImagesApi(mockHttpClient);
     const options: DeepSnakeCase<ExportImageOptions> = {
       ids: ['1:1'],
       use_absolute_bounds: true,
     };
 
-    await imagesApi.exportImages(TestData.FILE_KEY, options);
+    await imagesApi(mockHttpClient, TestData.FILE_KEY, options);
 
     const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
     expect(calledParams?.toString()).toContain('use_absolute_bounds=true');
   });
 
   test('バージョンオプションを指定してエクスポートできる', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       err: undefined,
       images: { '1:1': 'https://example.com/image.png' },
     };
 
     vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-    const imagesApi = createImagesApi(mockHttpClient);
     const options: DeepSnakeCase<ExportImageOptions> = {
       ids: ['1:1'],
       version: '123456',
     };
 
-    await imagesApi.exportImages(TestData.FILE_KEY, options);
+    await imagesApi(mockHttpClient, TestData.FILE_KEY, options);
 
     const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
     expect(calledParams?.toString()).toContain('version=123456');
   });
 
   test('すべてのオプションを組み合わせてエクスポートできる', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       err: undefined,
       images: { '1:1': 'https://example.com/image.png' },
     };
 
     vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-    const imagesApi = createImagesApi(mockHttpClient);
     const options: DeepSnakeCase<ExportImageOptions> = {
       ids: ['1:1', '2:2'],
       scale: 3,
@@ -185,11 +177,11 @@ describe('createImagesApi - exportImages', () => {
       version: '789',
     };
 
-    await imagesApi.exportImages(TestData.FILE_KEY, options);
+    await imagesApi(mockHttpClient, TestData.FILE_KEY, options);
 
     const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
     const paramString = calledParams?.toString() ?? '';
-    
+
     expect(paramString).toContain('ids=1%3A1%2C2%3A2');
     expect(paramString).toContain('scale=3');
     expect(paramString).toContain('format=pdf');
@@ -198,19 +190,18 @@ describe('createImagesApi - exportImages', () => {
   });
 
   test('エラーレスポンスを正しく処理できる', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       err: 'Invalid node ID',
       images: {},
     };
 
     vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-    const imagesApi = createImagesApi(mockHttpClient);
     const options: DeepSnakeCase<ExportImageOptions> = {
       ids: ['invalid'],
     };
 
-    const result = await imagesApi.exportImages(TestData.FILE_KEY, options);
+    const result = await imagesApi(mockHttpClient, TestData.FILE_KEY, options);
 
     expect(result.err).toBe('Invalid node ID');
     expect(Object.keys(result.images)).toHaveLength(0);
@@ -220,47 +211,46 @@ describe('createImagesApi - exportImages', () => {
     const expectedError = new Error('Network error');
     vi.mocked(mockHttpClient.get).mockRejectedValueOnce(expectedError);
 
-    const imagesApi = createImagesApi(mockHttpClient);
     const options: DeepSnakeCase<ExportImageOptions> = {
       ids: ['1:1'],
     };
 
-    await expect(imagesApi.exportImages(TestData.FILE_KEY, options)).rejects.toThrow('Network error');
+    await expect(imagesApi(mockHttpClient, TestData.FILE_KEY, options)).rejects.toThrow(
+      'Network error'
+    );
   });
 
   test('空のidsが渡された場合でも処理される', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       err: undefined,
       images: {},
     };
 
     vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-    const imagesApi = createImagesApi(mockHttpClient);
     const options: DeepSnakeCase<ExportImageOptions> = {
       ids: [],
     };
 
-    await imagesApi.exportImages(TestData.FILE_KEY, options);
+    await imagesApi(mockHttpClient, TestData.FILE_KEY, options);
 
     const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
     expect(calledParams?.toString()).toBe('ids=');
   });
 
   test('特殊文字を含むnode IDが適切にエンコードされる', async () => {
-    const mockResponse: ExportImageResponse = {
+    const mockResponse: ImageApiResponse = {
       err: undefined,
       images: {},
     };
 
     vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-    const imagesApi = createImagesApi(mockHttpClient);
     const options: DeepSnakeCase<ExportImageOptions> = {
       ids: ['I:123', 'S;456', '7:8'],
     };
 
-    await imagesApi.exportImages(TestData.FILE_KEY, options);
+    await imagesApi(mockHttpClient, TestData.FILE_KEY, options);
 
     const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
     expect(calledParams?.toString()).toBe('ids=I%3A123%2CS%3B456%2C7%3A8');

--- a/src/api/endpoints/images/index.ts
+++ b/src/api/endpoints/images/index.ts
@@ -1,37 +1,30 @@
-// 画像エクスポート関連のAPI関数
+// 画像エクスポート関連のAPI呼び出し関数
 
 import type { HttpClient } from '../../client.js';
-import type { ExportImageResponse } from '../../../types/index.js';
+import type { ImageApiResponse } from '../../../types/index.js';
 import type { ExportImageOptions } from '../../../types/api/options/image-options.js';
 import type { DeepSnakeCase } from '../../../utils/type-transformers.js';
 
-export interface ImagesApi {
-  exportImages: (fileKey: string, options: DeepSnakeCase<ExportImageOptions>) => Promise<ExportImageResponse>;
-}
+export async function imagesApi(
+  client: HttpClient,
+  fileKey: string,
+  options: DeepSnakeCase<ExportImageOptions>
+): Promise<ImageApiResponse> {
+  const params = new URLSearchParams();
 
-export function createImagesApi(client: HttpClient): ImagesApi {
-  return {
-    exportImages: async (
-      fileKey: string,
-      options: DeepSnakeCase<ExportImageOptions>
-    ): Promise<ExportImageResponse> => {
-      const params = new URLSearchParams();
+  params.append('ids', options.ids.join(','));
+  if (options.scale) params.append('scale', options.scale.toString());
+  if (options.format) params.append('format', options.format);
+  if (options.svg_include_id !== undefined) {
+    params.append('svg_include_id', options.svg_include_id.toString());
+  }
+  if (options.svg_simplify_stroke !== undefined) {
+    params.append('svg_simplify_stroke', options.svg_simplify_stroke.toString());
+  }
+  if (options.use_absolute_bounds !== undefined) {
+    params.append('use_absolute_bounds', options.use_absolute_bounds.toString());
+  }
+  if (options.version) params.append('version', options.version);
 
-      params.append('ids', options.ids.join(','));
-      if (options.scale) params.append('scale', options.scale.toString());
-      if (options.format) params.append('format', options.format);
-      if (options.svg_include_id !== undefined) {
-        params.append('svg_include_id', options.svg_include_id.toString());
-      }
-      if (options.svg_simplify_stroke !== undefined) {
-        params.append('svg_simplify_stroke', options.svg_simplify_stroke.toString());
-      }
-      if (options.use_absolute_bounds !== undefined) {
-        params.append('use_absolute_bounds', options.use_absolute_bounds.toString());
-      }
-      if (options.version) params.append('version', options.version);
-
-      return client.get<ExportImageResponse>(`/v1/images/${fileKey}`, params);
-    },
-  };
+  return client.get<ImageApiResponse>(`/v1/images/${fileKey}`, params);
 }

--- a/src/api/figma-api-client.ts
+++ b/src/api/figma-api-client.ts
@@ -5,7 +5,7 @@ import { getFileNodesApi } from './endpoints/file-nodes/index.js';
 import { createNodesApi } from './endpoints/nodes/index.js';
 import { fileComponentsApi, fileComponentSetsApi } from './endpoints/components/index.js';
 import { createStylesApi } from './endpoints/styles/index.js';
-import { createImagesApi } from './endpoints/images/index.js';
+import { imagesApi } from './endpoints/images/index.js';
 import { getFileCommentsApi } from './endpoints/comments/index.js';
 import { createVersionsApi } from './endpoints/versions/index.js';
 import { createTeamsApi } from './endpoints/teams/index.js';
@@ -17,7 +17,7 @@ import type {
   FileComponentSetsApiResponse,
 } from '../types/api/responses/component-responses.js';
 import type { GetStylesResponse } from '../types/api/responses/style-responses.js';
-import type { ExportImageResponse } from '../types/api/responses/image-responses.js';
+import type { ImageApiResponse } from '../types/api/responses/image-responses.js';
 import type { GetFileCommentsApiResponse } from '../types/api/responses/comment-responses.js';
 import type { GetVersionsResponse } from '../types/api/responses/version-responses.js';
 import type { ExportImageOptions } from '../types/api/options/image-options.js';
@@ -36,8 +36,6 @@ export interface FigmaApiClient {
   readonly nodes: ReturnType<typeof createNodesApi>;
   /** Styles API endpoint */
   readonly styles: ReturnType<typeof createStylesApi>;
-  /** Images API endpoint */
-  readonly images: ReturnType<typeof createImagesApi>;
   /** Versions API endpoint */
   readonly versions: ReturnType<typeof createVersionsApi>;
   /** Teams API endpoint */
@@ -66,7 +64,6 @@ export namespace FigmaApiClient {
       httpClient,
       nodes: createNodesApi(httpClient),
       styles: createStylesApi(httpClient),
-      images: createImagesApi(httpClient),
       versions: createVersionsApi(httpClient),
       teams: createTeamsApi(httpClient),
     };
@@ -84,7 +81,6 @@ export namespace FigmaApiClient {
       httpClient,
       nodes: createNodesApi(httpClient),
       styles: createStylesApi(httpClient),
-      images: createImagesApi(httpClient),
       versions: createVersionsApi(httpClient),
       teams: createTeamsApi(httpClient),
     };
@@ -149,9 +145,9 @@ export namespace FigmaApiClient {
     client: FigmaApiClient,
     fileKey: string,
     options: ExportImageOptions
-  ): Promise<ExportImageResponse> {
+  ): Promise<ImageApiResponse> {
     const snakeOptions = convertKeysToSnakeCase(options);
-    const response = await client.images.exportImages(fileKey, snakeOptions);
+    const response = await imagesApi(client.httpClient, fileKey, snakeOptions);
     return convertKeysToCamelCase(response);
   }
 

--- a/src/tools/image/export.ts
+++ b/src/tools/image/export.ts
@@ -1,5 +1,5 @@
 import { FigmaApiClient } from '../../api/figma-api-client.js';
-import type { ExportImageResponse } from '../../types/api/responses/image-responses.js';
+import type { ImageApiResponse } from '../../types/api/responses/image-responses.js';
 import { ExportImagesArgsSchema, type ExportImagesArgs } from './export-images-args.js';
 import { JsonSchema, type McpToolDefinition } from '../types.js';
 
@@ -33,7 +33,7 @@ export const ExportImagesTool = {
   /**
    * 画像エクスポートを実行
    */
-  async execute(tool: ExportImagesTool, args: ExportImagesArgs): Promise<ExportImageResponse> {
+  async execute(tool: ExportImagesTool, args: ExportImagesArgs): Promise<ImageApiResponse> {
     const { fileKey, ...options } = args;
     return FigmaApiClient.exportImages(tool.apiClient, fileKey, options);
   },

--- a/src/types/api/responses/image-responses.ts
+++ b/src/types/api/responses/image-responses.ts
@@ -1,6 +1,6 @@
 // 画像エクスポート関連のAPIレスポンス型定義
 
-export interface ExportImageResponse {
+export interface ImageApiResponse {
   err?: string;
   images: Record<string, string>;
   status?: number;


### PR DESCRIPTION
## 概要
images APIのエンドポイント実装を関数ベースのパターンに変更しました。これは、componentsエンドポイントで採用されているパターンと同じもので、コードベース全体の一貫性を向上させます。

## 変更内容
### 🔧 APIエンドポイントの変更
- `createImagesApi`関数と`ImagesApi`インターフェースを削除
- `imagesApi`関数として直接エクスポートする形式に変更
- APIパスに基づく命名規則を採用（`/v1/images` → `imagesApi`）

### 📝 型定義の変更
- レスポンス型名を`ExportImageResponse`から`ImageApiResponse`に変更
- 全ての関連ファイルで型名を統一

### ✅ テストの更新
- テストファイル名を`export-images.test.ts`から`images-api.test.ts`に変更
- 全てのテストが合格することを確認

### 📚 その他の変更
- devcontainer.jsonのフォーマット修正
- .gitignoreにLSMCPキャッシュを追加
- CLAUDE.mdにLSMCPツール使用ガイドラインを追加

## テスト
- ✅ `npm test` - 全テスト合格
- ✅ `npm run check` - TypeScript型チェック合格
- ✅ `npm run lint` - ESLintチェック合格

## 関連するファイル
- `src/api/endpoints/images/index.ts`
- `src/api/endpoints/images/__tests__/images-api.test.ts`
- `src/types/api/responses/image-responses.ts`
- `src/api/figma-api-client.ts`
- `src/tools/image/export.ts`
- `src/api/data/image/`配下のファイル

## チェックリスト
- [x] コードが正しくコンパイルされる
- [x] 既存のテストが全て合格する
- [x] 型定義が適切に更新されている
- [x] 命名規則が他のエンドポイントと一貫性がある