### PR TITLE
♻️ [Refactoring]: nodes APIを関数ベースに変更しbuildUrlParamsヘルパーを適用

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,6 +32,8 @@ RUN apt-get update && apt-get install -y \
     locales \
     language-pack-ja \
     fonts-noto-cjk \
+    ripgrep \
+    vim \
     && locale-gen ja_JP.UTF-8 \
     && update-locale LANG=ja_JP.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
@@ -55,8 +57,6 @@ RUN apt-get update && apt-get install -y \
     fcitx-mozc \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Claude Code CLI
-RUN npm install -g @anthropic-ai/claude-code
 
 # Copy built binaries from build stages
 COPY --from=github-builder /tmp/github-mcp-server/github-mcp-server /usr/local/bin/
@@ -70,6 +70,12 @@ RUN chmod +x /usr/local/bin/github-mcp-server \
 USER node
 WORKDIR /home/node
 
+# Install Claude Code CLI
+# RUN npm install -g @anthropic-ai/claude-code
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+ENV PATH="/home/node/.local/bin:${PATH}"
+
 # Set up workspace
 WORKDIR /workspace
 
@@ -81,6 +87,7 @@ RUN git config --global pull.rebase true \
     && git config --global alias.st status \
     && git config --global alias.lg "log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit" \
     && git config --global init.defaultBranch main 
+
 
 # Expose port for MCP server (using 8765 instead of 3001)
 EXPOSE 8765

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,4 +39,5 @@
       "version": "latest",
     },
   },
+  "mounts": ["source=${localEnv:HOME}/.gitconfig,target=/home/node/.gitconfig,type=bind,readonly"],
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ..:/workspace:cached
       - cargo_cache:/home/node/.cargo
     ports:
-      - "8765:8765"
+      - '8765:8765'
     environment:
       - NODE_ENV=development
       - GITHUB_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}

--- a/src/api/endpoints/nodes/__tests__/get-nodes.test.ts
+++ b/src/api/endpoints/nodes/__tests__/get-nodes.test.ts
@@ -1,12 +1,12 @@
 import { test, expect, vi } from 'vitest';
-import { createNodesApi } from '../index';
+import { getNodesApi } from '../index';
 import type { HttpClient } from '../../../client';
 import type { GetNodesResponse } from '../../../../types';
 import type { DeepSnakeCase } from '../../../../utils/type-transformers';
 import type { GetNodesOptions } from '../../../../types/api/options/node-options';
 import { TestData } from '../../../../constants';
 
-test('createNodesApi.getNodes - ノード情報を取得できる', async () => {
+test('getNodesApi - ノード情報を取得できる', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
@@ -29,24 +29,23 @@ test('createNodesApi.getNodes - ノード情報を取得できる', async () => 
 
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const nodesApi = createNodesApi(mockHttpClient);
   const options: DeepSnakeCase<GetNodesOptions> = {
     ids: ['1:1'],
   };
 
-  const result = await nodesApi.getNodes(TestData.FILE_KEY, options);
+  const result = await getNodesApi(mockHttpClient, TestData.FILE_KEY, options);
 
   expect(mockHttpClient.get).toHaveBeenCalledWith(
     '/v1/files/test-file-key/nodes',
     expect.any(URLSearchParams)
   );
-  
+
   const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
   expect(calledParams?.toString()).toContain('ids=1%3A1');
   expect(result).toEqual(mockResponse);
 });
 
-test('createNodesApi.getNodes - 複数のノードを取得できる', async () => {
+test('getNodesApi - 複数のノードを取得できる', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
@@ -78,19 +77,18 @@ test('createNodesApi.getNodes - 複数のノードを取得できる', async () 
 
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const nodesApi = createNodesApi(mockHttpClient);
   const options: DeepSnakeCase<GetNodesOptions> = {
     ids: ['1:1', '2:2'],
   };
 
-  const result = await nodesApi.getNodes(TestData.FILE_KEY, options);
+  const result = await getNodesApi(mockHttpClient, TestData.FILE_KEY, options);
 
   const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
   expect(calledParams?.toString()).toContain('ids=1%3A1%2C2%3A2');
   expect(Object.keys(result.nodes)).toHaveLength(2);
 });
 
-test('createNodesApi.getNodes - バージョンオプションを指定して取得できる', async () => {
+test('getNodesApi - バージョンオプションを指定して取得できる', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
@@ -99,19 +97,18 @@ test('createNodesApi.getNodes - バージョンオプションを指定して取
   const mockResponse = { nodes: {} } as GetNodesResponse;
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const nodesApi = createNodesApi(mockHttpClient);
   const options: DeepSnakeCase<GetNodesOptions> = {
     ids: ['1:1'],
     version: '789',
   };
 
-  await nodesApi.getNodes(TestData.FILE_KEY, options);
+  await getNodesApi(mockHttpClient, TestData.FILE_KEY, options);
 
   const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
   expect(calledParams?.toString()).toContain('version=789');
 });
 
-test('createNodesApi.getNodes - depthオプションを指定して取得できる', async () => {
+test('getNodesApi - depthオプションを指定して取得できる', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
@@ -120,19 +117,18 @@ test('createNodesApi.getNodes - depthオプションを指定して取得でき�
   const mockResponse = { nodes: {} } as GetNodesResponse;
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const nodesApi = createNodesApi(mockHttpClient);
   const options: DeepSnakeCase<GetNodesOptions> = {
     ids: ['1:1'],
     depth: 3,
   };
 
-  await nodesApi.getNodes(TestData.FILE_KEY, options);
+  await getNodesApi(mockHttpClient, TestData.FILE_KEY, options);
 
   const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
   expect(calledParams?.toString()).toContain('depth=3');
 });
 
-test('createNodesApi.getNodes - geometryオプションを指定して取得できる', async () => {
+test('getNodesApi - geometryオプションを指定して取得できる', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
@@ -141,19 +137,18 @@ test('createNodesApi.getNodes - geometryオプションを指定して取得で�
   const mockResponse = { nodes: {} } as GetNodesResponse;
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const nodesApi = createNodesApi(mockHttpClient);
   const options: DeepSnakeCase<GetNodesOptions> = {
     ids: ['1:1'],
     geometry: 'paths',
   };
 
-  await nodesApi.getNodes(TestData.FILE_KEY, options);
+  await getNodesApi(mockHttpClient, TestData.FILE_KEY, options);
 
   const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
   expect(calledParams?.toString()).toContain('geometry=paths');
 });
 
-test('createNodesApi.getNodes - plugin_dataオプションを指定して取得できる', async () => {
+test('getNodesApi - plugin_dataオプションを指定して取得できる', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
@@ -162,19 +157,18 @@ test('createNodesApi.getNodes - plugin_dataオプションを指定して取得�
   const mockResponse = { nodes: {} } as GetNodesResponse;
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const nodesApi = createNodesApi(mockHttpClient);
   const options: DeepSnakeCase<GetNodesOptions> = {
     ids: ['1:1'],
     plugin_data: 'my-plugin',
   };
 
-  await nodesApi.getNodes(TestData.FILE_KEY, options);
+  await getNodesApi(mockHttpClient, TestData.FILE_KEY, options);
 
   const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
   expect(calledParams?.toString()).toContain('plugin_data=my-plugin');
 });
 
-test('createNodesApi.getNodes - すべてのオプションを組み合わせて取得できる', async () => {
+test('getNodesApi - すべてのオプションを組み合わせて取得できる', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
@@ -183,7 +177,6 @@ test('createNodesApi.getNodes - すべてのオプションを組み合わせて
   const mockResponse = { nodes: {} } as GetNodesResponse;
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const nodesApi = createNodesApi(mockHttpClient);
   const options: DeepSnakeCase<GetNodesOptions> = {
     ids: ['1:1', '2:2', '3:3'],
     version: '456',
@@ -192,11 +185,11 @@ test('createNodesApi.getNodes - すべてのオプションを組み合わせて
     plugin_data: 'test-plugin',
   };
 
-  await nodesApi.getNodes(TestData.FILE_KEY, options);
+  await getNodesApi(mockHttpClient, TestData.FILE_KEY, options);
 
   const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
   const paramString = calledParams?.toString() ?? '';
-  
+
   expect(paramString).toContain('ids=1%3A1%2C2%3A2%2C3%3A3');
   expect(paramString).toContain('version=456');
   expect(paramString).toContain('depth=2');
@@ -204,7 +197,7 @@ test('createNodesApi.getNodes - すべてのオプションを組み合わせて
   expect(paramString).toContain('plugin_data=test-plugin');
 });
 
-test('createNodesApi.getNodes - depthが0の場合も正しくパラメータ化される', async () => {
+test('getNodesApi - depthが0の場合も正しくパラメータ化される', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
@@ -213,19 +206,18 @@ test('createNodesApi.getNodes - depthが0の場合も正しくパラメータ化
   const mockResponse = { nodes: {} } as GetNodesResponse;
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const nodesApi = createNodesApi(mockHttpClient);
   const options: DeepSnakeCase<GetNodesOptions> = {
     ids: ['1:1'],
     depth: 0,
   };
 
-  await nodesApi.getNodes(TestData.FILE_KEY, options);
+  await getNodesApi(mockHttpClient, TestData.FILE_KEY, options);
 
   const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
   expect(calledParams?.toString()).toContain('depth=0');
 });
 
-test('createNodesApi.getNodes - 空のidsでも処理される', async () => {
+test('getNodesApi - 空のidsでも処理される', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
@@ -234,18 +226,17 @@ test('createNodesApi.getNodes - 空のidsでも処理される', async () => {
   const mockResponse = { nodes: {} } as GetNodesResponse;
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const nodesApi = createNodesApi(mockHttpClient);
   const options: DeepSnakeCase<GetNodesOptions> = {
     ids: [],
   };
 
-  await nodesApi.getNodes(TestData.FILE_KEY, options);
+  await getNodesApi(mockHttpClient, TestData.FILE_KEY, options);
 
   const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
   expect(calledParams?.toString()).toBe('ids=');
 });
 
-test('createNodesApi.getNodes - 特殊文字を含むnode IDが適切にエンコードされる', async () => {
+test('getNodesApi - 特殊文字を含むnode IDが適切にエンコードされる', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
@@ -254,18 +245,17 @@ test('createNodesApi.getNodes - 特殊文字を含むnode IDが適切にエン�
   const mockResponse = { nodes: {} } as GetNodesResponse;
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const nodesApi = createNodesApi(mockHttpClient);
   const options: DeepSnakeCase<GetNodesOptions> = {
     ids: ['I:123', 'S;456', '7:8'],
   };
 
-  await nodesApi.getNodes(TestData.FILE_KEY, options);
+  await getNodesApi(mockHttpClient, TestData.FILE_KEY, options);
 
   const calledParams = vi.mocked(mockHttpClient.get).mock.calls[0][1];
   expect(calledParams?.toString()).toContain('ids=I%3A123%2CS%3B456%2C7%3A8');
 });
 
-test('createNodesApi.getNodes - HTTPクライアントがエラーをスローした場合、エラーが伝播される', async () => {
+test('getNodesApi - HTTPクライアントがエラーをスローした場合、エラーが伝播される', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
@@ -274,15 +264,16 @@ test('createNodesApi.getNodes - HTTPクライアントがエラーをスロー�
   const expectedError = new Error('Network error');
   vi.mocked(mockHttpClient.get).mockRejectedValueOnce(expectedError);
 
-  const nodesApi = createNodesApi(mockHttpClient);
   const options: DeepSnakeCase<GetNodesOptions> = {
     ids: ['1:1'],
   };
 
-  await expect(nodesApi.getNodes(TestData.FILE_KEY, options)).rejects.toThrow('Network error');
+  await expect(getNodesApi(mockHttpClient, TestData.FILE_KEY, options)).rejects.toThrow(
+    'Network error'
+  );
 });
 
-test('createNodesApi.getNodes - タイムアウトエラーが適切に処理される', async () => {
+test('getNodesApi - タイムアウトエラーが適切に処理される', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
@@ -291,10 +282,11 @@ test('createNodesApi.getNodes - タイムアウトエラーが適切に処理さ
   const timeoutError = new Error('Request timeout');
   vi.mocked(mockHttpClient.get).mockRejectedValueOnce(timeoutError);
 
-  const nodesApi = createNodesApi(mockHttpClient);
   const options: DeepSnakeCase<GetNodesOptions> = {
     ids: ['1:1'],
   };
 
-  await expect(nodesApi.getNodes(TestData.FILE_KEY, options)).rejects.toThrow('Request timeout');
+  await expect(getNodesApi(mockHttpClient, TestData.FILE_KEY, options)).rejects.toThrow(
+    'Request timeout'
+  );
 });

--- a/src/api/endpoints/nodes/index.ts
+++ b/src/api/endpoints/nodes/index.ts
@@ -1,26 +1,18 @@
-// ノード関連のAPI関数
+// ノード関連のAPI呼び出し関数
 
 import type { HttpClient } from '../../client.js';
 import type { GetNodesResponse } from '../../../types/index.js';
 import type { GetNodesOptions } from '../../../types/api/options/node-options.js';
 import type { DeepSnakeCase } from '../../../utils/type-transformers.js';
+import { buildUrlParams } from '../utils/params-builder.js';
 
-export interface NodesApi {
-  getNodes: (fileKey: string, options: DeepSnakeCase<GetNodesOptions>) => Promise<GetNodesResponse>;
-}
+export async function getNodesApi(
+  client: HttpClient,
+  fileKey: string,
+  options: DeepSnakeCase<GetNodesOptions>
+): Promise<GetNodesResponse> {
+  const { ids, ...restOptions } = options;
+  const params = buildUrlParams(restOptions, { ids });
 
-export function createNodesApi(client: HttpClient): NodesApi {
-  return {
-    getNodes: async (fileKey: string, options: DeepSnakeCase<GetNodesOptions>): Promise<GetNodesResponse> => {
-      const params = new URLSearchParams();
-
-      params.append('ids', options.ids.join(','));
-      if (options.version) params.append('version', options.version);
-      if (options.depth !== undefined) params.append('depth', options.depth.toString());
-      if (options.geometry) params.append('geometry', options.geometry);
-      if (options.plugin_data) params.append('plugin_data', options.plugin_data);
-
-      return client.get<GetNodesResponse>(`/v1/files/${fileKey}/nodes`, params);
-    },
-  };
+  return client.get<GetNodesResponse>(`/v1/files/${fileKey}/nodes`, params);
 }

--- a/src/api/figma-api-client.ts
+++ b/src/api/figma-api-client.ts
@@ -2,7 +2,7 @@ import { createApiConfig } from './config.js';
 import { createHttpClient, type HttpClient } from './client.js';
 import { getFileApi } from './endpoints/file/index.js';
 import { getFileNodesApi } from './endpoints/file-nodes/index.js';
-import { createNodesApi } from './endpoints/nodes/index.js';
+import { getNodesApi } from './endpoints/nodes/index.js';
 import { fileComponentsApi, fileComponentSetsApi } from './endpoints/components/index.js';
 import { createStylesApi } from './endpoints/styles/index.js';
 import { imagesApi } from './endpoints/images/index.js';
@@ -21,7 +21,13 @@ import type { ImageApiResponse } from '../types/api/responses/image-responses.js
 import type { GetFileCommentsApiResponse } from '../types/api/responses/comment-responses.js';
 import type { GetVersionsResponse } from '../types/api/responses/version-responses.js';
 import type { ImageApiOptions } from '../types/api/options/image-options.js';
-import type { FigmaFile, GetFileOptions, GetFileNodesResponse } from '../types/index.js';
+import type {
+  FigmaFile,
+  GetFileOptions,
+  GetFileNodesResponse,
+  GetNodesResponse,
+  GetNodesOptions,
+} from '../types/index.js';
 
 /**
  * FigmaApiClientのデータ構造
@@ -32,8 +38,6 @@ export interface FigmaApiClient {
   readonly context: FigmaContext;
   /** HTTP Client */
   readonly httpClient: HttpClient;
-  /** Nodes API endpoint */
-  readonly nodes: ReturnType<typeof createNodesApi>;
   /** Styles API endpoint */
   readonly styles: ReturnType<typeof createStylesApi>;
   /** Versions API endpoint */
@@ -62,7 +66,6 @@ export namespace FigmaApiClient {
     return {
       context,
       httpClient,
-      nodes: createNodesApi(httpClient),
       styles: createStylesApi(httpClient),
       versions: createVersionsApi(httpClient),
       teams: createTeamsApi(httpClient),
@@ -79,7 +82,6 @@ export namespace FigmaApiClient {
     return {
       context,
       httpClient,
-      nodes: createNodesApi(httpClient),
       styles: createStylesApi(httpClient),
       versions: createVersionsApi(httpClient),
       teams: createTeamsApi(httpClient),
@@ -196,6 +198,19 @@ export namespace FigmaApiClient {
   ): Promise<GetFileNodesResponse> {
     const response = await getFileNodesApi(client.httpClient, fileKey, ids, options);
     return convertKeysToCamelCase(response) as GetFileNodesResponse;
+  }
+
+  /**
+   * ノード情報を取得（キャメルケース変換付き）
+   */
+  export async function getNodes(
+    client: FigmaApiClient,
+    fileKey: string,
+    options: GetNodesOptions
+  ): Promise<GetNodesResponse> {
+    const snakeOptions = convertKeysToSnakeCase(options);
+    const response = await getNodesApi(client.httpClient, fileKey, snakeOptions);
+    return convertKeysToCamelCase(response) as GetNodesResponse;
   }
 }
 


### PR DESCRIPTION
## 概要
nodes APIエンドポイントを関数ベースのアーキテクチャに変更し、コードの一貫性と保守性を向上させました。

## 変更内容
- 🔄 `createNodesApi` を `getNodesApi` 関数に変更
- 🛠️ 手動のURLSearchParams構築を `buildUrlParams` ヘルパー関数使用に変更
- ✅ 全テストケースを新しい関数形式に対応
- 📦 FigmaApiClientから`nodes`プロパティを削除し、`getNodes`ヘルパー関数を追加

## 背景
commentsエンドポイントの実装パターンに合わせて、統一的なコード構造にするためのリファクタリングです。

## テスト
- ✅ 型チェック (`npm run check`) - パス
- ✅ 単体テスト (`npm test`) - 全12テストがパス
- ✅ Lint (`npm run lint`) - エラーなし

## 関連
- #53 - images APIのbuildUrlParams適用

🤖 Generated with [Claude Code](https://claude.ai/code)