### PR TITLE
♻️ [Refactoring]: styles APIを関数ベースの実装に変更し、レスポンス型名を統一

### DIFF
--- a/src/api/endpoints/styles/__tests__/get-styles.test.ts
+++ b/src/api/endpoints/styles/__tests__/get-styles.test.ts
@@ -1,16 +1,16 @@
 import { test, expect, vi } from 'vitest';
-import { createStylesApi } from '../index';
+import { getStylesApi } from '../index';
 import type { HttpClient } from '../../../client';
-import type { GetStylesResponse } from '../../../../types';
+import type { GetStylesApiResponse } from '../../../../types';
 import { TestData } from '../../../../constants';
 
-test('createStylesApi.getStyles - スタイル一覧を取得できる', async () => {
+test('getStylesApi - スタイル一覧を取得できる', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
   };
 
-  const mockResponse: GetStylesResponse = {
+  const mockResponse: GetStylesApiResponse = {
     error: false,
     meta: {
       styles: [
@@ -28,22 +28,19 @@ test('createStylesApi.getStyles - スタイル一覧を取得できる', async (
 
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const stylesApi = createStylesApi(mockHttpClient);
-  const result = await stylesApi.getStyles(TestData.FILE_KEY);
+  const result = await getStylesApi(mockHttpClient, TestData.FILE_KEY);
 
-  expect(mockHttpClient.get).toHaveBeenCalledWith(
-    '/v1/files/test-file-key/styles'
-  );
+  expect(mockHttpClient.get).toHaveBeenCalledWith('/v1/files/test-file-key/styles');
   expect(result).toEqual(mockResponse);
 });
 
-test('createStylesApi.getStyles - 空のスタイル一覧を取得できる', async () => {
+test('getStylesApi - 空のスタイル一覧を取得できる', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
   };
 
-  const mockResponse: GetStylesResponse = {
+  const mockResponse: GetStylesApiResponse = {
     error: false,
     meta: {
       styles: [],
@@ -52,19 +49,18 @@ test('createStylesApi.getStyles - 空のスタイル一覧を取得できる', a
 
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const stylesApi = createStylesApi(mockHttpClient);
-  const result = await stylesApi.getStyles(TestData.FILE_KEY);
+  const result = await getStylesApi(mockHttpClient, TestData.FILE_KEY);
 
   expect(result.meta.styles).toHaveLength(0);
 });
 
-test('createStylesApi.getStyles - 複数のスタイルタイプを正しく取得できる', async () => {
+test('getStylesApi - 複数のスタイルタイプを正しく取得できる', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
   };
 
-  const mockResponse: GetStylesResponse = {
+  const mockResponse: GetStylesApiResponse = {
     error: false,
     meta: {
       styles: [
@@ -98,8 +94,7 @@ test('createStylesApi.getStyles - 複数のスタイルタイプを正しく取�
 
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const stylesApi = createStylesApi(mockHttpClient);
-  const result = await stylesApi.getStyles(TestData.FILE_KEY);
+  const result = await getStylesApi(mockHttpClient, TestData.FILE_KEY);
 
   expect(result.meta.styles).toHaveLength(3);
   expect(result.meta.styles[0].styleType).toBe('FILL');
@@ -107,13 +102,13 @@ test('createStylesApi.getStyles - 複数のスタイルタイプを正しく取�
   expect(result.meta.styles[2].styleType).toBe('EFFECT');
 });
 
-test('createStylesApi.getStyles - エラーレスポンスを正しく処理できる', async () => {
+test('getStylesApi - エラーレスポンスを正しく処理できる', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
   };
 
-  const mockResponse: GetStylesResponse = {
+  const mockResponse: GetStylesApiResponse = {
     error: true,
     status: 403,
     meta: {
@@ -123,20 +118,19 @@ test('createStylesApi.getStyles - エラーレスポンスを正しく処理で�
 
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const stylesApi = createStylesApi(mockHttpClient);
-  const result = await stylesApi.getStyles(TestData.FILE_KEY);
+  const result = await getStylesApi(mockHttpClient, TestData.FILE_KEY);
 
   expect(result.error).toBe(true);
   expect(result.status).toBe(403);
 });
 
-test('createStylesApi.getStyles - 説明がないスタイルも正しく取得できる', async () => {
+test('getStylesApi - 説明がないスタイルも正しく取得できる', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
   };
 
-  const mockResponse: GetStylesResponse = {
+  const mockResponse: GetStylesApiResponse = {
     error: false,
     meta: {
       styles: [
@@ -154,13 +148,12 @@ test('createStylesApi.getStyles - 説明がないスタイルも正しく取得�
 
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const stylesApi = createStylesApi(mockHttpClient);
-  const result = await stylesApi.getStyles(TestData.FILE_KEY);
+  const result = await getStylesApi(mockHttpClient, TestData.FILE_KEY);
 
   expect(result.meta.styles[0].description).toBe('');
 });
 
-test('createStylesApi.getStyles - HTTPクライアントがエラーをスローした場合、エラーが伝播される', async () => {
+test('getStylesApi - HTTPクライアントがエラーをスローした場合、エラーが伝播される', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
@@ -169,12 +162,10 @@ test('createStylesApi.getStyles - HTTPクライアントがエラーをスロー
   const expectedError = new Error('Network error');
   vi.mocked(mockHttpClient.get).mockRejectedValueOnce(expectedError);
 
-  const stylesApi = createStylesApi(mockHttpClient);
-
-  await expect(stylesApi.getStyles(TestData.FILE_KEY)).rejects.toThrow('Network error');
+  await expect(getStylesApi(mockHttpClient, TestData.FILE_KEY)).rejects.toThrow('Network error');
 });
 
-test('createStylesApi.getStyles - 認証エラーが適切に処理される', async () => {
+test('getStylesApi - 認証エラーが適切に処理される', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
@@ -183,33 +174,28 @@ test('createStylesApi.getStyles - 認証エラーが適切に処理される', a
   const authError = new Error('Unauthorized');
   vi.mocked(mockHttpClient.get).mockRejectedValueOnce(authError);
 
-  const stylesApi = createStylesApi(mockHttpClient);
-
-  await expect(stylesApi.getStyles(TestData.FILE_KEY)).rejects.toThrow('Unauthorized');
+  await expect(getStylesApi(mockHttpClient, TestData.FILE_KEY)).rejects.toThrow('Unauthorized');
 });
 
-test('createStylesApi.getStyles - 特殊文字を含むファイルキーが正しくエンコードされる', async () => {
+test('getStylesApi - 特殊文字を含むファイルキーが正しくエンコードされる', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
   };
 
-  const mockResponse: GetStylesResponse = {
+  const mockResponse: GetStylesApiResponse = {
     error: false,
     meta: { styles: [] },
   };
   vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
 
-  const stylesApi = createStylesApi(mockHttpClient);
   const specialFileKey = 'file:key/with-special@chars';
-  await stylesApi.getStyles(specialFileKey);
+  await getStylesApi(mockHttpClient, specialFileKey);
 
-  expect(mockHttpClient.get).toHaveBeenCalledWith(
-    '/v1/files/file:key/with-special@chars/styles'
-  );
+  expect(mockHttpClient.get).toHaveBeenCalledWith('/v1/files/file:key/with-special@chars/styles');
 });
 
-test('createStylesApi.getStyles - タイムアウトエラーが適切に処理される', async () => {
+test('getStylesApi - タイムアウトエラーが適切に処理される', async () => {
   const mockHttpClient: HttpClient = {
     get: vi.fn().mockImplementation(() => Promise.resolve()),
     post: vi.fn().mockImplementation(() => Promise.resolve()),
@@ -218,7 +204,5 @@ test('createStylesApi.getStyles - タイムアウトエラーが適切に処理�
   const timeoutError = new Error('Request timeout');
   vi.mocked(mockHttpClient.get).mockRejectedValueOnce(timeoutError);
 
-  const stylesApi = createStylesApi(mockHttpClient);
-
-  await expect(stylesApi.getStyles(TestData.FILE_KEY)).rejects.toThrow('Request timeout');
+  await expect(getStylesApi(mockHttpClient, TestData.FILE_KEY)).rejects.toThrow('Request timeout');
 });

--- a/src/api/endpoints/styles/index.ts
+++ b/src/api/endpoints/styles/index.ts
@@ -1,16 +1,11 @@
-// スタイル関連のAPI関数
+// スタイル関連のAPI呼び出し関数
 
 import type { HttpClient } from '../../client.js';
-import type { GetStylesResponse } from '../../../types/index.js';
+import type { GetStylesApiResponse } from '../../../types/index.js';
 
-export interface StylesApi {
-  getStyles: (fileKey: string) => Promise<GetStylesResponse>;
-}
-
-export function createStylesApi(client: HttpClient): StylesApi {
-  return {
-    getStyles: async (fileKey: string): Promise<GetStylesResponse> => {
-      return client.get<GetStylesResponse>(`/v1/files/${fileKey}/styles`);
-    },
-  };
+export async function getStylesApi(
+  client: HttpClient,
+  fileKey: string
+): Promise<GetStylesApiResponse> {
+  return client.get<GetStylesApiResponse>(`/v1/files/${fileKey}/styles`);
 }

--- a/src/api/figma-api-client.ts
+++ b/src/api/figma-api-client.ts
@@ -4,7 +4,7 @@ import { getFileApi } from './endpoints/file/index.js';
 import { getFileNodesApi } from './endpoints/file-nodes/index.js';
 import { getNodesApi } from './endpoints/nodes/index.js';
 import { fileComponentsApi, fileComponentSetsApi } from './endpoints/components/index.js';
-import { createStylesApi } from './endpoints/styles/index.js';
+import { getStylesApi } from './endpoints/styles/index.js';
 import { imagesApi } from './endpoints/images/index.js';
 import { getFileCommentsApi } from './endpoints/comments/index.js';
 import { createVersionsApi } from './endpoints/versions/index.js';
@@ -16,7 +16,7 @@ import type {
   FileComponentsApiResponse,
   FileComponentSetsApiResponse,
 } from '../types/api/responses/component-responses.js';
-import type { GetStylesResponse } from '../types/api/responses/style-responses.js';
+import type { GetStylesApiResponse } from '../types/api/responses/style-responses.js';
 import type { ImageApiResponse } from '../types/api/responses/image-responses.js';
 import type { GetFileCommentsApiResponse } from '../types/api/responses/comment-responses.js';
 import type { GetVersionsResponse } from '../types/api/responses/version-responses.js';
@@ -38,8 +38,6 @@ export interface FigmaApiClient {
   readonly context: FigmaContext;
   /** HTTP Client */
   readonly httpClient: HttpClient;
-  /** Styles API endpoint */
-  readonly styles: ReturnType<typeof createStylesApi>;
   /** Versions API endpoint */
   readonly versions: ReturnType<typeof createVersionsApi>;
   /** Teams API endpoint */
@@ -66,7 +64,6 @@ export namespace FigmaApiClient {
     return {
       context,
       httpClient,
-      styles: createStylesApi(httpClient),
       versions: createVersionsApi(httpClient),
       teams: createTeamsApi(httpClient),
     };
@@ -82,7 +79,6 @@ export namespace FigmaApiClient {
     return {
       context,
       httpClient,
-      styles: createStylesApi(httpClient),
       versions: createVersionsApi(httpClient),
       teams: createTeamsApi(httpClient),
     };
@@ -135,8 +131,8 @@ export namespace FigmaApiClient {
   export async function getStyles(
     client: FigmaApiClient,
     fileKey: string
-  ): Promise<GetStylesResponse> {
-    const response = await client.styles.getStyles(fileKey);
+  ): Promise<GetStylesApiResponse> {
+    const response = await getStylesApi(client.httpClient, fileKey);
     return convertKeysToCamelCase(response);
   }
 

--- a/src/tools/style/list.ts
+++ b/src/tools/style/list.ts
@@ -1,5 +1,5 @@
 import { FigmaApiClient } from '../../api/figma-api-client.js';
-import type { GetStylesResponse } from '../../types/api/responses/style-responses.js';
+import type { GetStylesApiResponse } from '../../types/api/responses/style-responses.js';
 import { GetStylesArgsSchema, type GetStylesArgs } from './get-styles-args.js';
 import { JsonSchema, type McpToolDefinition } from '../types.js';
 import { Style } from '../../models/style/style.js';
@@ -34,7 +34,7 @@ export const GetStylesTool = {
   /**
    * スタイル取得を実行
    */
-  async execute(tool: GetStylesTool, args: GetStylesArgs): Promise<GetStylesResponse> {
+  async execute(tool: GetStylesTool, args: GetStylesArgs): Promise<GetStylesApiResponse> {
     const response = await FigmaApiClient.getStyles(tool.apiClient, args.fileKey);
 
     if (args.categorize && response.meta.styles.length > 0) {

--- a/src/tools/style/types.ts
+++ b/src/tools/style/types.ts
@@ -1,5 +1,5 @@
 import type { ToolDefinition } from '../types.js';
-import type { GetStylesResponse } from '../../types/api/responses/style-responses.js';
+import type { GetStylesApiResponse } from '../../types/api/responses/style-responses.js';
 import type { GetStylesArgs } from './get-styles-args.js';
 
-export type StyleTool = ToolDefinition<GetStylesArgs, GetStylesResponse>;
+export type StyleTool = ToolDefinition<GetStylesArgs, GetStylesApiResponse>;

--- a/src/types/api/responses/style-responses.ts
+++ b/src/types/api/responses/style-responses.ts
@@ -8,7 +8,7 @@ export interface StyleStatistics {
   namingConsistency: number;
 }
 
-export interface GetStylesResponse {
+export interface GetStylesApiResponse {
   error?: boolean;
   status?: number;
   meta: {


### PR DESCRIPTION
## 📋 概要

styles APIエンドポイントをcomments APIと同様の関数ベースの実装パターンに変更し、レスポンス型の命名規則を統一しました。

## 🔄 変更内容

### 1. **styles APIの実装パターン変更**
- ✅ `StylesApi`インターフェースを削除
- ✅ `createStylesApi`ファクトリー関数を削除
- ✅ `getStylesApi`として直接関数をエクスポート
- ✅ 第1引数に`HttpClient`、第2引数に`fileKey`を受け取るシグネチャに統一

### 2. **レスポンス型の命名規則統一**
- ✅ `GetStylesResponse` → `GetStylesApiResponse`に改名
- ✅ 他のAPIレスポンス型（`GetFileCommentsApiResponse`など）と命名規則を統一

## 📝 変更ファイル

- `src/api/endpoints/styles/index.ts` - 関数ベースの実装に変更
- `src/api/figma-api-client.ts` - styles APIの呼び出し方法を更新
- `src/types/api/responses/style-responses.ts` - レスポンス型名を変更
- `src/api/endpoints/styles/__tests__/get-styles.test.ts` - テストを新しいシグネチャに対応
- `src/tools/style/types.ts` - 型定義を更新
- `src/tools/style/list.ts` - 新しい型名を使用

## ✅ テスト結果

- すべてのユニットテストが成功
- ESLintチェックが成功
- TypeScript型チェックが成功

## 💡 メリット

1. **一貫性の向上**: すべてのAPIエンドポイントが同じパターンで実装される
2. **シンプルさ**: 不要な抽象化を削除し、コードがより直感的に
3. **保守性**: 統一されたパターンにより、新しいエンドポイントの追加が容易に

## 🎯 影響範囲

この変更は内部実装の改善であり、外部APIには影響しません。

🤖 Generated with [Claude Code](https://claude.ai/code)