### PR TITLE
♻️ [Refactoring]: コンパニオンオブジェクトパターンで不要な型エイリアスを削除

### DIFF
--- a/src/models/comment/index.ts
+++ b/src/models/comment/index.ts
@@ -1,3 +1,3 @@
 // comment モデルの再エクスポート
 export { Comment } from './comment.js';
-export type { Comment as CommentType, CommentWithReplies, Reaction } from './comment.js';
+export type { CommentWithReplies, Reaction } from './comment.js';

--- a/src/models/style/index.ts
+++ b/src/models/style/index.ts
@@ -1,3 +1,3 @@
 // Style型とコンパニオンオブジェクトの再エクスポート
 export { Style } from './style.js';
-export type { Style as StyleType, CategorizedStyles } from './style.js';
+export type { CategorizedStyles } from './style.js';

--- a/src/tools/style/index.ts
+++ b/src/tools/style/index.ts
@@ -2,7 +2,7 @@
 export { GetStylesTool, GetStylesToolDefinition } from './list.js';
 export type { GetStylesArgs } from './get-styles-args.js';
 export { Style } from '../../models/style/style.js';
-export type { Style as StyleType, CategorizedStyles } from '../../models/style/style.js';
+export type { CategorizedStyles } from '../../models/style/style.js';
 
 // 互換性のために残しておく（後で削除予定）
 import type { FigmaApiClient } from '../../api/figma-api-client.js';


### PR DESCRIPTION
## 概要

コンパニオンオブジェクトパターンで不要になった型エイリアス（`as XXXType`）を削除し、TypeScriptの名前空間マージング機能を適切に活用するようにリファクタリングしました。

## 変更内容

### 🎯 変更の種類

- [x] ♻️ リファクタリング (Refactoring)

### 📝 詳細な変更内容

#### 削除された機能・修正

- `Comment as CommentType` の型エイリアスを削除
- `Style as StyleType` の型エイリアスを削除
- TypeScriptの名前空間マージング機能により、同名での型とオブジェクトの併用が可能なため不要な型エイリアスを除去

#### 変更されたファイル

- `src/models/comment/index.ts`: `Comment as CommentType` の型エイリアス削除
- `src/models/style/index.ts`: `Style as StyleType` の型エイリアス削除
- `src/tools/style/index.ts`: `Style as StyleType` の型エイリアス削除

#### 技術的な改善点

- TypeScriptの名前空間マージング機能を活用
- コード量の削減と可読性の向上
- 型システムの自然な活用により、より直感的なAPIを提供

## 🧪 テスト

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト (Integration tests)
- [x] 型チェック (Type checking)

### テスト結果

全ての既存テストが正常に実行されることを確認済み。型エイリアスの削除により、より自然なTypeScript APIになりました。

## 🔍 レビューポイント

- コンパニオンオブジェクトパターンの実装が適切か
- 型エイリアスの削除による影響がないか
- TypeScriptの名前空間マージング機能の活用が適切か

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] セルフレビューを実施した
- [x] TypeScriptの型チェックが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)