### PR TITLE
🚨 [Tests]: logger.test.tsのネストしたdescribeブロックをフラット化しテスト名を具体的に改善

### DIFF
--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -1,128 +1,118 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createConsoleLogger, LogLevel } from './logger.js';
 
-describe('Logger', () => {
-  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
-  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
-  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
-  beforeEach(() => {
-    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-  });
+beforeEach(() => {
+  consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
-  describe('基本機能', () => {
-    it('デバッグメッセージをログ出力できる', () => {
-      const logger = createConsoleLogger(LogLevel.DEBUG);
+test('DEBUGレベルのlogger.debugでコンソールに[DEBUG]タグ付きメッセージが出力される', () => {
+  const logger = createConsoleLogger(LogLevel.DEBUG);
 
-      logger.debug('デバッグメッセージ');
+  logger.debug('デバッグメッセージ');
 
-      expect(consoleLogSpy).toHaveBeenCalledTimes(1);
-      const call = consoleLogSpy.mock.calls[0];
-      expect(call[0]).toMatch(/\[DEBUG\]/);
-      expect(call[0]).toMatch(/デバッグメッセージ/);
-    });
+  expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+  const call = consoleLogSpy.mock.calls[0];
+  expect(call[0]).toMatch(/\[DEBUG\]/);
+  expect(call[0]).toMatch(/デバッグメッセージ/);
+});
 
-    it('情報メッセージをログ出力できる', () => {
-      const logger = createConsoleLogger();
+test('logger.infoでコンソールに[INFO]タグ付きメッセージが出力される', () => {
+  const logger = createConsoleLogger();
 
-      logger.info('情報メッセージ');
+  logger.info('情報メッセージ');
 
-      expect(consoleLogSpy).toHaveBeenCalledTimes(1);
-      const call = consoleLogSpy.mock.calls[0];
-      expect(call[0]).toMatch(/\[INFO\]/);
-      expect(call[0]).toMatch(/情報メッセージ/);
-    });
+  expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+  const call = consoleLogSpy.mock.calls[0];
+  expect(call[0]).toMatch(/\[INFO\]/);
+  expect(call[0]).toMatch(/情報メッセージ/);
+});
 
-    it('警告メッセージをログ出力できる', () => {
-      const logger = createConsoleLogger();
+test('logger.warnでconsole.warnに[WARN]タグ付きメッセージが出力される', () => {
+  const logger = createConsoleLogger();
 
-      logger.warn('警告メッセージ');
+  logger.warn('警告メッセージ');
 
-      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
-      const call = consoleWarnSpy.mock.calls[0];
-      expect(call[0]).toMatch(/\[WARN\]/);
-      expect(call[0]).toMatch(/警告メッセージ/);
-    });
+  expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+  const call = consoleWarnSpy.mock.calls[0];
+  expect(call[0]).toMatch(/\[WARN\]/);
+  expect(call[0]).toMatch(/警告メッセージ/);
+});
 
-    it('エラーメッセージをログ出力できる', () => {
-      const logger = createConsoleLogger();
+test('logger.errorでconsole.errorに[ERROR]タグ付きメッセージが出力される', () => {
+  const logger = createConsoleLogger();
 
-      logger.error('エラーメッセージ');
+  logger.error('エラーメッセージ');
 
-      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-      const call = consoleErrorSpy.mock.calls[0];
-      expect(call[0]).toMatch(/\[ERROR\]/);
-      expect(call[0]).toMatch(/エラーメッセージ/);
-    });
-  });
+  expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  const call = consoleErrorSpy.mock.calls[0];
+  expect(call[0]).toMatch(/\[ERROR\]/);
+  expect(call[0]).toMatch(/エラーメッセージ/);
+});
 
-  describe('ログレベル制御', () => {
-    it('ログレベルより低いメッセージは出力されない', () => {
-      const logger = createConsoleLogger(LogLevel.WARN);
+test('WARNレベルに設定するとDEBUGとINFOメッセージは出力されない', () => {
+  const logger = createConsoleLogger(LogLevel.WARN);
 
-      logger.debug('デバッグ');
-      logger.info('情報');
-      logger.warn('警告');
+  logger.debug('デバッグ');
+  logger.info('情報');
+  logger.warn('警告');
 
-      expect(consoleLogSpy).not.toHaveBeenCalled();
-      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
-    });
+  expect(consoleLogSpy).not.toHaveBeenCalled();
+  expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+});
 
-    it('ログレベルをOFFにすると何も出力されない', () => {
-      const logger = createConsoleLogger(LogLevel.OFF);
+test('OFFレベルに設定すると全てのログが出力されない', () => {
+  const logger = createConsoleLogger(LogLevel.OFF);
 
-      logger.debug('デバッグ');
-      logger.info('情報');
-      logger.warn('警告');
-      logger.error('エラー');
+  logger.debug('デバッグ');
+  logger.info('情報');
+  logger.warn('警告');
+  logger.error('エラー');
 
-      expect(consoleLogSpy).not.toHaveBeenCalled();
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
-    });
-  });
+  expect(consoleLogSpy).not.toHaveBeenCalled();
+  expect(consoleWarnSpy).not.toHaveBeenCalled();
+  expect(consoleErrorSpy).not.toHaveBeenCalled();
+});
 
-  describe('データ付きログ', () => {
-    it('追加データと一緒にログ出力できる', () => {
-      const logger = createConsoleLogger();
-      const data = { userId: 123, action: 'login' };
+test('オブジェクトデータをメッセージと一緒に出力できる', () => {
+  const logger = createConsoleLogger();
+  const data = { userId: 123, action: 'login' };
 
-      logger.info('ユーザーアクション', data);
+  logger.info('ユーザーアクション', data);
 
-      expect(consoleLogSpy).toHaveBeenCalledTimes(1);
-      const call = consoleLogSpy.mock.calls[0];
-      expect(call[0]).toMatch(/ユーザーアクション/);
-      expect(call[1]).toEqual(data);
-    });
+  expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+  const call = consoleLogSpy.mock.calls[0];
+  expect(call[0]).toMatch(/ユーザーアクション/);
+  expect(call[1]).toEqual(data);
+});
 
-    it('データがない場合は空文字列が出力される', () => {
-      const logger = createConsoleLogger();
+test('データ引数を省略すると空文字列が第2引数として出力される', () => {
+  const logger = createConsoleLogger();
 
-      logger.info('メッセージのみ');
+  logger.info('メッセージのみ');
 
-      expect(consoleLogSpy).toHaveBeenCalledTimes(1);
-      const call = consoleLogSpy.mock.calls[0];
-      expect(call[0]).toMatch(/メッセージのみ/);
-      expect(call[1]).toBe('');
-    });
-  });
+  expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+  const call = consoleLogSpy.mock.calls[0];
+  expect(call[0]).toMatch(/メッセージのみ/);
+  expect(call[1]).toBe('');
+});
 
-  describe('ログレベル変更', () => {
-    it('実行時にログレベルを変更できる', () => {
-      const logger = createConsoleLogger(LogLevel.ERROR);
+test('setLevelで実行中にログレベルを変更できる', () => {
+  const logger = createConsoleLogger(LogLevel.ERROR);
 
-      logger.info('出力されない');
-      expect(consoleLogSpy).not.toHaveBeenCalled();
+  logger.info('出力されない');
+  expect(consoleLogSpy).not.toHaveBeenCalled();
 
-      logger.setLevel(LogLevel.INFO);
-      logger.info('出力される');
-      expect(consoleLogSpy).toHaveBeenCalledTimes(1);
-    });
-  });
+  logger.setLevel(LogLevel.INFO);
+  logger.info('出力される');
+  expect(consoleLogSpy).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
## 概要

logger.test.tsのテスト構造をリファクタリングし、可読性と保守性を向上させました。

## 変更内容

- ネストした`describe`ブロックを削除し、フラットな構造に変更
- テスト名をより具体的で説明的なものに改善
- `it`から`test`に変更（Vitestの推奨スタイル）
- トップレベルに`beforeEach`と`afterEach`を移動

## 改善効果

- **可読性向上**: テスト名だけで何をテストしているか明確に理解できる
- **保守性向上**: フラットな構造により、テストの追加・修正が容易
- **一貫性**: Vitestの推奨プラクティスに準拠

## テスト範囲

すべてのテストが正常にパスすることを確認済み。機能的な変更はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)